### PR TITLE
ブックマークのデータを管理するコンポーネントを独立する作業を先にするために、一時中断する。ここまでの結果でマージする。

### DIFF
--- a/src/app/components/bmDetail.test.tsx
+++ b/src/app/components/bmDetail.test.tsx
@@ -6,7 +6,6 @@ import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { MessageProvider } from "../contexts/MessageContext";
-
 import { BmDetail } from "./bmDetail";
 import BmMessage from "./bmMessage";
 
@@ -27,15 +26,19 @@ describe("BmDetail", () => {
     );
 
     const urlInput = screen.getByLabelText("url");
+    const textInput = screen.getByLabelText("title") as HTMLInputElement;
     const updateButton = screen.getByText("更新");
 
     fireEvent.change(urlInput, {
       target: { value: url },
     });
+    fireEvent.change(textInput, {
+      target: { value: "Gmail" },
+    });
     fireEvent.click(updateButton);
 
     expect(onBmUpdate).toHaveBeenCalledTimes(1);
-    expect(onBmUpdate).toHaveBeenCalledWith(url, "");
+    expect(onBmUpdate).toHaveBeenCalledWith(url, "Gmail");
   });
 
   it("すべてのエレメントが表示される", () => {
@@ -166,5 +169,26 @@ describe("BmDetail", () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock.mock.calls[0][0]).toEqual("/api/title?url=" + url);
     });
+  });
+
+  it("URLが空白の場合、タイトルボタン、更新ボタンが無効になっている。", async () => {
+    const onBmUpdate = jest.fn();
+
+    render(
+      <MessageProvider>
+        <BmMessage />
+        <BmDetail onBmUpdate={onBmUpdate} />
+      </MessageProvider>
+    );
+
+    const urlInput = screen.getByLabelText("url");
+    const titleButton = screen.getByText("タイトル");
+    const updateButton = screen.getByText("更新");
+
+    fireEvent.change(urlInput, {
+      target: { value: "" },
+    });
+    expect(titleButton).toBeDisabled();
+    expect(updateButton).toBeDisabled();
   });
 });

--- a/src/app/components/bmDetail.tsx
+++ b/src/app/components/bmDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { useMessage } from "../contexts/MessageContext";
 
@@ -11,6 +11,8 @@ export const BmDetail: React.FC<BmDetailProps> = ({
 }) => {
   const [textUrl, setTextUrl] = useState("");
   const [textTitle, setTextTitle] = useState("");
+  const [textUrlDisabled, setTextUrlDisabled] = useState(true);
+  const [textTitleDisabled, setTextTitleDisabled] = useState(true);
   const textUrlRef1 = useRef<HTMLInputElement>(null);
   const textTitleRef2 = useRef<HTMLInputElement>(null);
   const { setMessage } = useMessage();
@@ -35,6 +37,20 @@ export const BmDetail: React.FC<BmDetailProps> = ({
     }
   };
 
+  useEffect(() => {
+    if (textUrl === "") {
+      setTextUrlDisabled(true);
+      setTextTitleDisabled(true);
+    } else {
+      setTextUrlDisabled(false);
+      if (textTitle === "") {
+        setTextTitleDisabled(true);
+      } else {
+        setTextTitleDisabled(false);
+      }
+    }
+  }, [textUrl, textTitle]);
+
   return (
     <div>
       <input
@@ -51,8 +67,12 @@ export const BmDetail: React.FC<BmDetailProps> = ({
         onChange={(e) => setTextTitle(e.target.value)}
         ref={textTitleRef2}
       />
-      <button onClick={titleClick}>タイトル</button>
-      <button onClick={updateClick}>更新</button>
+      <button onClick={titleClick} disabled={textUrlDisabled}>
+        タイトル
+      </button>
+      <button onClick={updateClick} disabled={textTitleDisabled}>
+        更新
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
URL入力欄が空白の場合にタイトルボタンと更新ボタンが無効になるテストを追加しました。また、値がある場合は有効になることを確認しました。