### PR TITLE
ブックマークをクリックした後の処理を修正した

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/components/BookmarkManager/delete.test.tsx
+++ b/src/app/components/BookmarkManager/delete.test.tsx
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { BOOKMARKS_ENDPOINT } from "../../constants/apiEndpoints";
-import { clickBookmark } from "../../test-utils/click.test";
+import { clickBookmark } from "../../test-utils/bookmarkTestUtils";
 import { DELETE_BUTTON_ROLE_NAME } from "../../test-utils/constants";
 import { mockBookmarks } from "../../types/Bookmark";
 import { BookmarkManager } from "../BookmarkManager";

--- a/src/app/components/BookmarkManager/errorClose.test.tsx
+++ b/src/app/components/BookmarkManager/errorClose.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import { clickBookmark } from "../../test-utils/click.test";
+import { clickBookmark } from "../../test-utils/bookmarkTestUtils";
 import {
   CLOSE_BUTTON_ROLE_NAME,
   TITLE_ROLE_NAME,

--- a/src/app/components/BookmarkManager/hotkeys.test.tsx
+++ b/src/app/components/BookmarkManager/hotkeys.test.tsx
@@ -13,7 +13,7 @@ import {
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import { clickBookmark } from "../../test-utils/click.test";
+import { clickBookmark } from "../../test-utils/bookmarkTestUtils";
 import { TITLE_ROLE_NAME, URL_ROLE_NAME } from "../../test-utils/constants";
 import { Bookmark, mockBookmarks } from "../../types/Bookmark";
 import { BookmarkManager } from "../BookmarkManager";

--- a/src/app/components/BookmarkManager/open.test.tsx
+++ b/src/app/components/BookmarkManager/open.test.tsx
@@ -13,7 +13,7 @@ import {
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import { clickBookmark } from "../../test-utils/click.test";
+import { clickBookmark } from "../../test-utils/bookmarkTestUtils";
 import { URL_ROLE_NAME } from "../../test-utils/constants";
 import { mockBookmarks } from "../../types/Bookmark";
 import { BookmarkManager } from "../BookmarkManager";

--- a/src/app/components/BookmarkManager/parameter.test.tsx
+++ b/src/app/components/BookmarkManager/parameter.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import { clickBookmark } from "../../test-utils/click.test";
+import { clickBookmark } from "../../test-utils/bookmarkTestUtils";
 import {
   PARAMETER_BUTTON_ROLE_NAME,
   URL_ROLE_NAME,

--- a/src/app/components/BookmarkManager/path.test.tsx
+++ b/src/app/components/BookmarkManager/path.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import { clickBookmark } from "../../test-utils/click.test";
+import { clickBookmark } from "../../test-utils/bookmarkTestUtils";
 import {
   ARROW_BUTTON_ROLE_NAME,
   URL_ROLE_NAME,

--- a/src/app/components/BookmarkManager/select.test.tsx
+++ b/src/app/components/BookmarkManager/select.test.tsx
@@ -38,33 +38,6 @@ describe("ブックマークの選択", () => {
     });
   });
 
-  it("テーブル内のブックマーク行をクリックすると、URLとタイトルのテキストボックスにそのブックマークの情報が表示される。「選択解除」のボタンが表示される。", async () => {
-    // mockFetchはbeforeEachでmockBookmarksを返すように設定されています
-
-    await act(async () => {
-      render(<BookmarkManager />);
-    });
-
-    // 初期データがロードされ、UIが安定するのを待つ
-    // テーブル内に既知のブックマークのタイトルが表示されることを確認
-    // また、アクションボタンが表示されていることで、メインUIの準備ができていることを確認
-    await waitFor(() => {
-      expect(screen.getByText(mockBookmarks[0].title)).toBeInTheDocument();
-    });
-
-    // クリックするブックマークを選択（例：2番目のブックマーク）
-    const bookmarkToSelect = mockBookmarks[1]; // Google
-    await clickBookmark(bookmarkToSelect);
-
-    // BookmarkManager内のuseEffectによって入力フィールドが更新されるのを待つ
-    await waitFor(() => {
-      const urlInput = screen.getByRole("textbox", { name: URL_ROLE_NAME });
-      const titleInput = screen.getByRole("textbox", { name: TITLE_ROLE_NAME });
-      expect(urlInput).toHaveValue(bookmarkToSelect.url);
-      expect(titleInput).toHaveValue(bookmarkToSelect.title);
-    });
-  });
-
   it("選択解除のボタンをクリックすると、URLとタイトルのテキストボックスがクリアされる。選択解除のボタンが表示されていない。", async () => {
     // mockFetchはbeforeEachでmockBookmarksを返すように設定されています
 
@@ -82,14 +55,6 @@ describe("ブックマークの選択", () => {
     // クリックするブックマークを選択（例：2番目のブックマーク）
     const bookmarkToSelect = mockBookmarks[1]; // Google
     await clickBookmark(bookmarkToSelect);
-
-    // BookmarkManager内のuseEffectによって入力フィールドが更新されるのを待つ;
-    await waitFor(() => {
-      const urlInput = screen.getByRole("textbox", { name: URL_ROLE_NAME });
-      const titleInput = screen.getByRole("textbox", { name: TITLE_ROLE_NAME });
-      expect(urlInput).toHaveValue(bookmarkToSelect.url);
-      expect(titleInput).toHaveValue(bookmarkToSelect.title);
-    });
 
     await act(async () => {
       fireEvent.keyDown(document.body, { key: "Escape", code: "Escape" });

--- a/src/app/components/BookmarkManager/select.test.tsx
+++ b/src/app/components/BookmarkManager/select.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import { clickBookmark } from "../../test-utils/click.test";
+import { clickBookmark } from "../../test-utils/bookmarkTestUtils";
 import { Bookmark, mockBookmarks } from "../../types/Bookmark";
 import { BookmarkManager } from "../BookmarkManager";
 import { URL_ROLE_NAME, TITLE_ROLE_NAME } from "../../test-utils/constants";

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { BOOKMARKS_ENDPOINT } from "../../constants/apiEndpoints";
-import { clickBookmark } from "../../test-utils/click.test";
+import { clickBookmark } from "../../test-utils/bookmarkTestUtils";
 import {
   TITLE_ROLE_NAME,
   UPDATE_BUTTON_ROLE_NAME,

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -3,7 +3,7 @@ import { expect } from "vitest";
 
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 
-import { TITLE_ROLE_NAME, URL_ROLE_NAME } from "../test-utils/constants";
+import { TITLE_ROLE_NAME, URL_ROLE_NAME } from "./constants";
 import { Bookmark } from "../types/Bookmark";
 
 export const clickBookmark = async (bookmark: Bookmark) => {

--- a/src/app/test-utils/click.test.tsx
+++ b/src/app/test-utils/click.test.tsx
@@ -3,7 +3,7 @@ import { expect } from "vitest";
 
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 
-import { URL_ROLE_NAME } from "../test-utils/constants";
+import { TITLE_ROLE_NAME, URL_ROLE_NAME } from "../test-utils/constants";
 import { Bookmark } from "../types/Bookmark";
 
 export const clickBookmark = async (bookmark: Bookmark) => {
@@ -22,6 +22,9 @@ export const clickBookmark = async (bookmark: Bookmark) => {
       expect(screen.getByRole("textbox", { name: URL_ROLE_NAME })).toHaveValue(
         bookmark.url
       );
+      expect(
+        screen.getByRole("textbox", { name: TITLE_ROLE_NAME })
+      ).toHaveValue(bookmark.title);
     });
   } catch (error) {
     // エラーメッセージに元のエラーを含めるとデバッグが容易になります


### PR DESCRIPTION
クリックした後でテキストボックスが表示される確認はヘルパー関数で実行するため、呼び出し側では実行しない。