### PR TITLE
feat(keyword): ブックマークへのキーワード追加機能を実装

### DIFF
--- a/src/app/components/BookmarkManager.tsx
+++ b/src/app/components/BookmarkManager.tsx
@@ -16,13 +16,11 @@ import { BookmarkInputField } from "./BookmarkInputField";
 import { BookmarkTable } from "./BookmarkTable";
 import { ErrorMessage } from "./ErrorMessage";
 import { KeywordTable } from "./KeywordTable";
-import { Keyword } from "../types/Keyword";
-
-import { BOOKMARKS_ENDPOINT } from "../constants/apiEndpoints";
 
 export const BookmarkManager = () => {
   const {
     bookmarks,
+    keywords,
     isError,
     textUrl,
     textTitle,
@@ -38,52 +36,8 @@ export const BookmarkManager = () => {
     pathClick,
     handleErrorClose,
     updateClick,
+    addKeywordClick,
   } = useBookmarkManager();
-
-  const [keywords, setKeywords] = React.useState<Keyword[]>([]);
-
-  React.useEffect(() => {
-    if (selectedBookmark) {
-      setKeywords(selectedBookmark.keywords);
-    }
-  }, [selectedBookmark]);
-
-  const addKeywordClick = async () => {
-    if (!textKeyword) {
-      return;
-    }
-    try {
-      if (!selectedBookmark) {
-        return;
-      }
-      const response = await fetch(
-        `${BOOKMARKS_ENDPOINT}/${selectedBookmark.bookmark_id}/keywords`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ keyword_name: textKeyword }),
-        }
-      );
-      if (!response.ok) {
-        throw new Error("キーワードの追加に失敗しました。");
-      }
-      // const newKeyword = await response.json();
-      // setKeywords([...keywords, newKeyword]);
-      const responseData = await response.json();
-      const newKeyword: Keyword = {
-        keyword_id: responseData.keyword_id,
-        keyword_name: responseData.keyword_name,
-      };
-      setKeywords([...keywords, newKeyword]);
-      setTextKeyword("");
-      selectedBookmark.keywords.push(newKeyword);
-    } catch (error: unknown) {
-      console.error("キーワードの追加エラー:", (error as Error).message); // 詳細なエラーはコンソールへ
-      throw error;
-    }
-  };
 
   return (
     <>

--- a/src/app/hooks/useBookmark.ts
+++ b/src/app/hooks/useBookmark.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 
 import { BOOKMARKS_ENDPOINT } from "../constants/apiEndpoints";
 import { Bookmark } from "../types/Bookmark";
+import { Keyword } from "../types/Keyword";
 
 export class DuplicatedUrlError extends Error {
   constructor(message: string) {
@@ -38,9 +39,7 @@ export const useBookmarks = () => {
 
       if (response.ok) {
         setBookmarks((currentBookmarks) =>
-          currentBookmarks.filter(
-            (bookmark) => bookmark.bookmark_id !== bookmark_id
-          )
+          currentBookmarks.filter((bookmark) => bookmark.bookmark_id !== bookmark_id)
         );
       } else {
         const json = await response.json();
@@ -52,46 +51,73 @@ export const useBookmarks = () => {
     }
   }, []);
 
-  const updateBookmark = useCallback(
-    async (bookmark_id: number, url: string, title: string) => {
-      try {
-        const response = await fetch(`${BOOKMARKS_ENDPOINT}/${bookmark_id}`, {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ url, title }),
-        });
-        if (response.ok) {
-          // APIが更新後のオブジェクトを返さないため、ローカルでタイトルを更新
-          setBookmarks((currentBookmarks) =>
-            currentBookmarks.map((bookmark) =>
-              bookmark.bookmark_id === bookmark_id
-                ? { ...bookmark, url, title }
-                : bookmark
-            )
-          );
+  const updateBookmark = useCallback(async (bookmark_id: number, url: string, title: string) => {
+    try {
+      const response = await fetch(`${BOOKMARKS_ENDPOINT}/${bookmark_id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ url, title }),
+      });
+      if (response.ok) {
+        // APIが更新後のオブジェクトを返さないため、ローカルでタイトルを更新
+        setBookmarks((currentBookmarks) =>
+          currentBookmarks.map((bookmark) =>
+            bookmark.bookmark_id === bookmark_id ? { ...bookmark, url, title } : bookmark
+          )
+        );
+      } else {
+        // エラーレスポンスの処理
+        const json = await response.json();
+        if (response.status === 409) {
+          throw new DuplicatedUrlError(json.message);
         } else {
-          // エラーレスポンスの処理
-          const json = await response.json();
-          if (response.status === 409) {
-            throw new DuplicatedUrlError(json.message);
-          } else {
-            throw new Error(`[${response.status}] ${json.message}`);
-          }
+          throw new Error(`[${response.status}] ${json.message}`);
         }
-      } catch (error: unknown) {
-        console.error("ブックマークの更新エラー:", (error as Error).message); // 詳細なエラーはコンソールへ
-        throw error;
       }
-    },
-    []
-  );
+    } catch (error: unknown) {
+      console.error("ブックマークの更新エラー:", (error as Error).message); // 詳細なエラーはコンソールへ
+      throw error;
+    }
+  }, []);
+
+  const addKeyword = useCallback(async (bookmark_id: number, keyword_name: string) => {
+    try {
+      const response = await fetch(`${BOOKMARKS_ENDPOINT}/${bookmark_id}/keywords`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ keyword_name: keyword_name }),
+      });
+      if (!response.ok) {
+        throw new Error("キーワードの追加に失敗しました。");
+      }
+      const responseData = await response.json();
+      const newKeyword: Keyword = {
+        keyword_id: responseData.keyword_id,
+        keyword_name: responseData.keyword_name,
+      };
+      setBookmarks((currentBookmarks) =>
+        currentBookmarks.map((bookmark) =>
+          bookmark.bookmark_id === bookmark_id
+            ? { ...bookmark, keywords: [...bookmark.keywords, newKeyword] }
+            : bookmark
+        )
+      );
+      return newKeyword;
+    } catch (error: unknown) {
+      console.error("キーワードの追加エラー:", (error as Error).message); // 詳細なエラーはコンソールへ
+      throw error;
+    }
+  }, []);
 
   return {
     bookmarks,
     getBookmarks,
     deleteBookmark,
     updateBookmark,
+    addKeyword,
   };
 };

--- a/src/app/hooks/useBookmarkManager.test.tsx
+++ b/src/app/hooks/useBookmarkManager.test.tsx
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { renderHook, act, waitFor } from "@testing-library/react";
 
-import { useBookmarkManager } from "./useBookmarkManager";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
 import { mockBookmarks } from "../test-utils/bookmarkTestUtils";
+import { useBookmarkManager } from "./useBookmarkManager";
 
 const mockFetch = vi.fn();
 
@@ -40,6 +41,51 @@ describe("useBookmarkManager", () => {
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("ブックマークにキーワードを設定する", async () => {
+    const newKeyword = "new keyword";
+    const newKeywordResponse = { keyword_id: 99, keyword_name: newKeyword };
+    const { result } = renderHook(() => useBookmarkManager());
+
+    // 1. 初期データがロードされるのを待つ
+    await waitFor(() => {
+      expect(result.current.bookmarks).toHaveLength(mockBookmarks.length);
+    });
+
+    // 2. キーワード追加APIのレスポンスをモックする
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => newKeywordResponse,
+    });
+
+    // 3. ブックマークを選択する
+    act(() => {
+      result.current.setSelectedBookmark(mockBookmarks[0]);
+    });
+
+    // 4. ブックマーク選択による副作用(useEffect)が完了し、フォームが更新されるのを待つ
+    await waitFor(() => {
+      expect(result.current.textUrl).toBe(mockBookmarks[0].url);
+    });
+
+    // 5. キーワードを入力し、追加アクションを実行する
+    act(() => {
+      result.current.setTextKeyword(newKeyword);
+    });
+    act(() => {
+      result.current.addKeywordClick();
+    });
+
+    // 6. 結果を検証する
+    await waitFor(() => {
+      // ブックマークの初期読み込みの1回とキーワードを設定する1回の合計2回
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      // keywords ステートに新しいキーワードが追加されていることを確認
+      expect(result.current.keywords).toContainEqual(newKeywordResponse);
     });
   });
 });

--- a/src/app/hooks/useBookmarkManager.ts
+++ b/src/app/hooks/useBookmarkManager.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import { SelectedBookmark } from "../types/Bookmark";
+import { Keyword } from "../types/Keyword";
 import { DuplicatedUrlError, useBookmarks } from "./useBookmark";
 import { useErrorMessage } from "./useErrorMessage";
 
@@ -12,8 +13,9 @@ export const useBookmarkManager = () => {
   const [textTitle, setTextTitle] = useState("");
   const [textKeyword, setTextKeyword] = useState("");
   const [selectedBookmark, setSelectedBookmark] = useState<SelectedBookmark>(undefined);
+  const [keywords, setKeywords] = useState<Keyword[]>([]);
 
-  const { bookmarks, getBookmarks, deleteBookmark, updateBookmark } = useBookmarks();
+  const { bookmarks, getBookmarks, deleteBookmark, updateBookmark, addKeyword } = useBookmarks();
 
   const { textMessage, setMessage, isError, handleErrorClose } = useErrorMessage();
 
@@ -56,6 +58,10 @@ export const useBookmarkManager = () => {
   }, [loadBookmarks]);
 
   useEffect(() => {
+    if (selectedBookmark) {
+      setKeywords(selectedBookmark.keywords);
+    }
+
     setTextKeyword("");
     if (selectedBookmark === undefined) {
       setTextUrl("");
@@ -228,8 +234,23 @@ export const useBookmarkManager = () => {
     ]
   );
 
+  const addKeywordClick = useCallback(async () => {
+    if (!textKeyword || !selectedBookmark) {
+      return;
+    }
+    try {
+      const newKeyword = await addKeyword(selectedBookmark.bookmark_id, textKeyword);
+      setKeywords((currentKeywords) => [...currentKeywords, newKeyword]);
+      setTextKeyword("");
+      setMessage();
+    } catch {
+      setMessage("キーワードの追加中にエラーが発生しました。", true);
+    }
+  }, [addKeyword, selectedBookmark, textKeyword, setTextKeyword, setMessage]);
+
   return {
     bookmarks,
+    keywords,
     textUrl,
     textTitle,
     textKeyword,
@@ -245,5 +266,6 @@ export const useBookmarkManager = () => {
     pathClick,
     handleErrorClose,
     updateClick,
+    addKeywordClick,
   };
 };


### PR DESCRIPTION
### 概要
ブックマークに対してキーワードを追加する機能を実装しました。 この変更により、ユーザーは各ブックマークに関連するキーワードを登録し、管理できるようになります。

### 変更内容
キーワード追加機能の実装にあたり、関心の分離を意識してリファクタリングを行いました。主な変更点は以下の通りです。

- useBookmarksフックの拡張:

  - キーワード追加のAPI通信をカプセル化するため、addKeyword関数を追加しました。

- useBookmarkManagerフックへのロジック集約:

  - キーワード入力用のtextKeywordと、選択されたブックマークに紐づくkeywordsの状態を管理するようにしました。
  - useBookmarksのaddKeywordを呼び出すaddKeywordClickハンドラを実装し、キーワード追加に関する一連の処理を集約しました。

- BookmarkManagerコンポーネントのリファクタリング:

  - useBookmarkManagerフックからキーワード関連の状態と関数を受け取るように変更しました。
  - これにより、コンポーネントはUIの描画に専念し、ビジネスロジックから分離されました。

### 目的

- 機能追加: ユーザーがブックマークにキーワードを関連付けられるようにする。
- 保守性の向上: 関連するロジックをカスタムフックに集約することで、コンポーネントの見通しを良くし、コードの保守性を高める。
- 関心の分離: UI（BookmarkManager）とビジネスロジック（useBookmarkManager, useBookmarks）の責務を明確に分離する。