### PR TITLE
refactor(test): fetchモックのレスポンス生成を共通ヘルパー関数に統一

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.11.9",
+  "version": "1.11.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.11.9",
+      "version": "1.11.10",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.11.9",
+  "version": "1.11.10",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/components/BookmarkManager/delete.test.tsx
+++ b/src/app/components/BookmarkManager/delete.test.tsx
@@ -6,8 +6,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { BOOKMARKS_ENDPOINT } from "../../constants/apiEndpoints";
-import { clickBookmark, mockBookmarks } from "../../test-utils/bookmarkTestUtils";
 import { DELETE_BUTTON_ROLE_NAME } from "../../constants/constants";
+import {
+  clickBookmark,
+  createMockResponse,
+  mockBookmarks,
+} from "../../test-utils/bookmarkTestUtils";
 import { BookmarkManager } from "../BookmarkManager";
 
 const mockFetch = vi.fn();
@@ -82,10 +86,7 @@ describe("削除ボタン", () => {
     // fetchMock.resetMocks();
     // fetchMock.mockResponseOnce("", { status: 204 });
     mockFetch.mockReset();
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 204,
-    });
+    mockFetch.mockResolvedValueOnce(createMockResponse({ isOk: true, status: 204 }));
 
     const deleteButton = screen.getByRole("button", {
       name: DELETE_BUTTON_ROLE_NAME,
@@ -132,14 +133,13 @@ describe("削除ボタン", () => {
     await clickBookmark(bookmarkToSelect);
 
     mockFetch.mockReset();
-    mockFetch.mockResolvedValueOnce({
-      ok: false, // 404の場合は false
-      status: 404,
-      headers: { "Content-Type": "application/json" },
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
         message: "指定されたブックマークがありません。",
-      }),
-    });
+        isOk: false,
+        status: 404,
+      })
+    );
 
     const deleteButton = screen.getByRole("button", {
       name: DELETE_BUTTON_ROLE_NAME,
@@ -179,14 +179,13 @@ describe("削除ボタン", () => {
     await clickBookmark(bookmarkToSelect);
 
     mockFetch.mockReset();
-    mockFetch.mockResolvedValueOnce({
-      ok: false, // 400の場合は false
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
         message: "リクエストにIDがありませんでした。",
-      }),
-    });
+        isOk: false,
+        status: 400,
+      })
+    );
 
     const deleteButton = screen.getByRole("button", {
       name: DELETE_BUTTON_ROLE_NAME,
@@ -222,14 +221,13 @@ describe("削除ボタン", () => {
     });
 
     mockFetch.mockReset();
-    mockFetch.mockResolvedValueOnce({
-      ok: false, // 500の場合は false
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
         message: "サーバーで予期せぬエラーが発生しました。",
-      }),
-    });
+        isOk: false,
+        status: 500,
+      })
+    );
 
     // クリックするブックマークを選択（例：2番目のブックマーク）
     const bookmarkToSelect = mockBookmarks[1]; // Google

--- a/src/app/components/BookmarkManager/keyword.add.test.tsx
+++ b/src/app/components/BookmarkManager/keyword.add.test.tsx
@@ -10,6 +10,7 @@ import {
   buildMockBookmarksWithKeywords,
   clickBookmark,
   findBookmarkWithAtLeastNKeywords,
+  createMockResponse,
 } from "../../test-utils/bookmarkTestUtils";
 import { Bookmark } from "../../types/Bookmark";
 import { BookmarkManager } from "../BookmarkManager";
@@ -40,177 +41,143 @@ describe("選択されたブックマークにキーワードを追加", () => {
     vi.restoreAllMocks();
   });
 
-  it("テキストボックスにキーワードを入力して「追加」ボタンをクリックするとAPIが呼び出される", async () => {
-    mockFetch.mockReset();
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 201,
-      json: async () => ({
-        message: "キーワードをブックマークに追加しました。",
-        keyword_id: 1,
-        bookmark_keyword_id: 123,
-        keyword_name: "テストキーワード",
-      }),
-    });
-    // キーワードが設定されていないブックマークを選択
-    const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(mockBookmarksWithKeywords, 0);
-    await clickBookmark(bookmarkToSelect);
-
-    const keywordInput = screen.getByRole("textbox", { name: KEYWORD_ROLE_NAME });
-    const addButton = screen.getByRole("button", { name: ADD_BUTTON_ROLE_NAME });
-
-    await act(async () => {
-      fireEvent.change(keywordInput, { target: { value: "テストキーワード" } });
-      fireEvent.click(addButton);
-    });
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-      expect(mockFetch.mock.calls[0][0]).toEqual(
-        `${BOOKMARKS_ENDPOINT}/${bookmarkToSelect.bookmark_id}/keywords`
+  describe("キーワードの設定に成功", () => {
+    beforeEach(async () => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse("キーワードをブックマークに追加しました。", "テストキーワード")
       );
-      expect(mockFetch.mock.calls[0][1]).toEqual({
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          keyword_name: "テストキーワード",
-        }),
-      });
-    });
-  });
-
-  it("テキストボックスにキーワードを入力して「追加」ボタンをクリックするとキーワードのテーブルに表示される", async () => {
-    mockFetch.mockReset();
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 201,
-      json: async () => ({
-        message: "キーワードをブックマークに追加しました。",
-        keyword_id: 1,
-        bookmark_keyword_id: 123,
-        keyword_name: "テストキーワード",
-      }),
-    });
-    // キーワードが設定されていないブックマークを選択
-    const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(mockBookmarksWithKeywords, 0);
-    await clickBookmark(bookmarkToSelect);
-
-    const keywordInput = screen.getByRole("textbox", { name: KEYWORD_ROLE_NAME });
-    const addButton = screen.getByRole("button", { name: ADD_BUTTON_ROLE_NAME });
-    const keywordTable = screen.getByRole("table", { name: "キーワードのテーブル" });
-
-    await waitFor(() => {
-      expect(keywordTable).toBeInTheDocument();
-      const rows = within(keywordTable).queryAllByRole("row");
-      expect(rows).toHaveLength(1);
     });
 
-    await act(async () => {
-      fireEvent.change(keywordInput, { target: { value: "テストキーワード" } });
-      fireEvent.click(addButton);
-    });
+    it("テキストボックスにキーワードを入力して「追加」ボタンをクリックするとAPIが呼び出される", async () => {
+      // キーワードが設定されていないブックマークを選択
+      const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(mockBookmarksWithKeywords, 0);
+      await clickBookmark(bookmarkToSelect);
 
-    await waitFor(() => {
-      expect(keywordTable).toBeInTheDocument();
-      const rows = within(keywordTable).queryAllByRole("row");
-      expect(rows).toHaveLength(2);
-      const cell = within(rows[1]).getByRole("cell");
-      expect(cell).toHaveTextContent("テストキーワード");
-      expect(keywordInput).toHaveValue("");
-    });
-  });
-
-  describe("キーワード追加後の状態遷移", () => {
-    const addNewKeyword = async () => {
       const keywordInput = screen.getByRole("textbox", { name: KEYWORD_ROLE_NAME });
       const addButton = screen.getByRole("button", { name: ADD_BUTTON_ROLE_NAME });
+
       await act(async () => {
         fireEvent.change(keywordInput, { target: { value: "テストキーワード" } });
         fireEvent.click(addButton);
       });
-    };
 
-    const deselectBookmark = async () => {
-      await act(async () => {
-        fireEvent.keyDown(document.body, { key: "Escape", code: "Escape" });
-      });
-    };
-
-    it("キーワードを追加した後にブックマークの選択を解除すると、キーワードのテーブルが表示されなくなる", async () => {
-      // 準備
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        json: async () => ({
-          message: "キーワードをブックマークに追加しました。",
-          keyword_id: 1,
-          bookmark_keyword_id: 123,
-          keyword_name: "テストキーワード",
-        }),
-      });
-      // キーワードが設定されていないブックマークを選択
-      const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(mockBookmarksWithKeywords, 0);
-      await clickBookmark(bookmarkToSelect);
-
-      // 事前のキーワードのテーブルに表示されている件数を確認
-      const keywordTable = screen.getByRole("table", { name: "キーワードのテーブル" });
       await waitFor(() => {
-        expect(within(keywordTable).queryAllByRole("row")).toHaveLength(1);
-      });
-
-      // 実行
-      // ブックマークにキーワードを追加
-      await addNewKeyword();
-      // ブックマークの選択を解除
-      await deselectBookmark();
-
-      // 検証
-      // キーワードのテーブルが表示されていないことを確認
-      await waitFor(() => {
-        expect(keywordTable).not.toBeInTheDocument();
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(mockFetch.mock.calls[0][0]).toEqual(
+          `${BOOKMARKS_ENDPOINT}/${bookmarkToSelect.bookmark_id}/keywords`
+        );
+        expect(mockFetch.mock.calls[0][1]).toEqual({
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            keyword_name: "テストキーワード",
+          }),
+        });
       });
     });
 
-    it("キーワードを追加した後にブックマークの選択を解除して、再度ブックマークを選択すると、追加したキーワードが表示される", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 201,
-        json: async () => ({
-          message: "キーワードをブックマークに追加しました。",
-          keyword_id: 1,
-          bookmark_keyword_id: 123,
-          keyword_name: "テストキーワード",
-        }),
-      });
+    it("テキストボックスにキーワードを入力して「追加」ボタンをクリックするとキーワードのテーブルに表示される", async () => {
       // キーワードが設定されていないブックマークを選択
       const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(mockBookmarksWithKeywords, 0);
       await clickBookmark(bookmarkToSelect);
 
-      // 事前のキーワードのテーブルに表示されている件数を確認
+      const keywordInput = screen.getByRole("textbox", { name: KEYWORD_ROLE_NAME });
+      const addButton = screen.getByRole("button", { name: ADD_BUTTON_ROLE_NAME });
+      const keywordTable = screen.getByRole("table", { name: "キーワードのテーブル" });
+
       await waitFor(() => {
-        const keywordTable = screen.getByRole("table", { name: "キーワードのテーブル" });
-        expect(within(keywordTable).queryAllByRole("row")).toHaveLength(1);
+        expect(keywordTable).toBeInTheDocument();
+        const rows = within(keywordTable).queryAllByRole("row");
+        expect(rows).toHaveLength(1);
       });
 
-      // 実行
-      // ブックマークにキーワードを追加
-      await addNewKeyword();
-      // ブックマークの選択を解除
-      await deselectBookmark();
-      // 同じブックマークを選択
-      await clickBookmark(bookmarkToSelect);
+      await act(async () => {
+        fireEvent.change(keywordInput, { target: { value: "テストキーワード" } });
+        fireEvent.click(addButton);
+      });
 
       await waitFor(() => {
-        const keywordTable = screen.getByRole("table", { name: "キーワードのテーブル" });
-        const keywordInput = screen.getByRole("textbox", { name: KEYWORD_ROLE_NAME });
-
         expect(keywordTable).toBeInTheDocument();
         const rows = within(keywordTable).queryAllByRole("row");
         expect(rows).toHaveLength(2);
-        expect(within(rows[1]).getByRole("cell")).toHaveTextContent("テストキーワード");
+        const cell = within(rows[1]).getByRole("cell");
+        expect(cell).toHaveTextContent("テストキーワード");
         expect(keywordInput).toHaveValue("");
+      });
+    });
+
+    describe("キーワード追加後の状態遷移", () => {
+      const addNewKeyword = async () => {
+        const keywordInput = screen.getByRole("textbox", { name: KEYWORD_ROLE_NAME });
+        const addButton = screen.getByRole("button", { name: ADD_BUTTON_ROLE_NAME });
+        await act(async () => {
+          fireEvent.change(keywordInput, { target: { value: "テストキーワード" } });
+          fireEvent.click(addButton);
+        });
+      };
+
+      const deselectBookmark = async () => {
+        await act(async () => {
+          fireEvent.keyDown(document.body, { key: "Escape", code: "Escape" });
+        });
+      };
+
+      it("キーワードを追加した後にブックマークの選択を解除すると、キーワードのテーブルが表示されなくなる", async () => {
+        // キーワードが設定されていないブックマークを選択
+        const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(mockBookmarksWithKeywords, 0);
+        await clickBookmark(bookmarkToSelect);
+
+        // 事前のキーワードのテーブルに表示されている件数を確認
+        const keywordTable = screen.getByRole("table", { name: "キーワードのテーブル" });
+        await waitFor(() => {
+          expect(within(keywordTable).queryAllByRole("row")).toHaveLength(1);
+        });
+
+        // 実行
+        // ブックマークにキーワードを追加
+        await addNewKeyword();
+        // ブックマークの選択を解除
+        await deselectBookmark();
+
+        // 検証
+        // キーワードのテーブルが表示されていないことを確認
+        await waitFor(() => {
+          expect(keywordTable).not.toBeInTheDocument();
+        });
+      });
+
+      it("キーワードを追加した後にブックマークの選択を解除して、再度ブックマークを選択すると、追加したキーワードが表示される", async () => {
+        // キーワードが設定されていないブックマークを選択
+        const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(mockBookmarksWithKeywords, 0);
+        await clickBookmark(bookmarkToSelect);
+
+        // 事前のキーワードのテーブルに表示されている件数を確認
+        await waitFor(() => {
+          const keywordTable = screen.getByRole("table", { name: "キーワードのテーブル" });
+          expect(within(keywordTable).queryAllByRole("row")).toHaveLength(1);
+        });
+
+        // 実行
+        // ブックマークにキーワードを追加
+        await addNewKeyword();
+        // ブックマークの選択を解除
+        await deselectBookmark();
+        // 同じブックマークを選択
+        await clickBookmark(bookmarkToSelect);
+
+        await waitFor(() => {
+          const keywordTable = screen.getByRole("table", { name: "キーワードのテーブル" });
+          const keywordInput = screen.getByRole("textbox", { name: KEYWORD_ROLE_NAME });
+
+          expect(keywordTable).toBeInTheDocument();
+          const rows = within(keywordTable).queryAllByRole("row");
+          expect(rows).toHaveLength(2);
+          expect(within(rows[1]).getByRole("cell")).toHaveTextContent("テストキーワード");
+          expect(keywordInput).toHaveValue("");
+        });
       });
     });
   });

--- a/src/app/components/BookmarkManager/keyword.add.test.tsx
+++ b/src/app/components/BookmarkManager/keyword.add.test.tsx
@@ -47,7 +47,7 @@ describe("選択されたブックマークにキーワードを追加", () => {
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
           message: "キーワードをブックマークに追加しました。",
-          keywordName: "テストキーワード",
+          keyword_name: "テストキーワード",
         })
       );
     });

--- a/src/app/components/BookmarkManager/keyword.add.test.tsx
+++ b/src/app/components/BookmarkManager/keyword.add.test.tsx
@@ -9,8 +9,8 @@ import { ADD_BUTTON_ROLE_NAME, KEYWORD_ROLE_NAME } from "../../constants/constan
 import {
   buildMockBookmarksWithKeywords,
   clickBookmark,
-  findBookmarkWithAtLeastNKeywords,
   createMockResponse,
+  findBookmarkWithAtLeastNKeywords,
 } from "../../test-utils/bookmarkTestUtils";
 import { Bookmark } from "../../types/Bookmark";
 import { BookmarkManager } from "../BookmarkManager";
@@ -45,7 +45,10 @@ describe("選択されたブックマークにキーワードを追加", () => {
     beforeEach(async () => {
       mockFetch.mockReset();
       mockFetch.mockResolvedValueOnce(
-        createMockResponse("キーワードをブックマークに追加しました。", "テストキーワード")
+        createMockResponse({
+          message: "キーワードをブックマークに追加しました。",
+          keywordName: "テストキーワード",
+        })
       );
     });
 

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -7,7 +7,11 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { BOOKMARKS_ENDPOINT } from "../../constants/apiEndpoints";
 import { TITLE_ROLE_NAME, UPDATE_BUTTON_ROLE_NAME, URL_ROLE_NAME } from "../../constants/constants";
-import { clickBookmark, mockBookmarks } from "../../test-utils/bookmarkTestUtils";
+import {
+  clickBookmark,
+  createMockResponse,
+  mockBookmarks,
+} from "../../test-utils/bookmarkTestUtils";
 import { BookmarkManager } from "../BookmarkManager";
 import { Bookmark } from "../../types/Bookmark";
 
@@ -88,10 +92,12 @@ describe("タイトルの更新ボタン", () => {
 
     const updateUrl = "https://www.google.com/mail";
     const updateTitle = "更新されたタイトル";
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 204,
-    });
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        isOk: true,
+        status: 204,
+      })
+    );
 
     await act(async () => {
       fireEvent.change(urlInput, { target: { value: updateUrl } });
@@ -167,13 +173,13 @@ describe("タイトルの更新ボタン", () => {
 
     const updateUrl = mockBookmarks[2].url;
     const updateTitle = "更新されたタイトル";
-    mockFetch.mockResolvedValueOnce({
-      ok: false, // 409の場合は false
-      status: 409,
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        isOk: false,
+        status: 409,
         message: "指定されたURLのブックマークは既に登録されています。",
-      }),
-    });
+      })
+    );
 
     await act(async () => {
       fireEvent.change(urlInput, { target: { value: updateUrl } });
@@ -207,14 +213,13 @@ describe("タイトルの更新ボタン", () => {
     const bookmarkToSelect = mockBookmarks[1]; // Google
     await clickBookmark(bookmarkToSelect);
 
-    mockFetch.mockResolvedValueOnce({
-      ok: false, // 404の場合は false
-      status: 404,
-      headers: { "Content-Type": "application/json" },
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        isOk: false,
+        status: 404,
         message: "指定されたブックマークがありません。",
-      }),
-    });
+      })
+    );
 
     const updateButton = screen.getByRole("button", {
       name: UPDATE_BUTTON_ROLE_NAME,
@@ -250,15 +255,13 @@ describe("タイトルの更新ボタン", () => {
     const bookmarkToSelect = mockBookmarks[1]; // Google
     await clickBookmark(bookmarkToSelect);
 
-    mockFetch.mockReset();
-    mockFetch.mockResolvedValueOnce({
-      ok: false, // 400の場合は false
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        isOk: false,
+        status: 400,
         message: "タイトルが指定されていません。",
-      }),
-    });
+      })
+    );
 
     const updateButton = screen.getByRole("button", {
       name: UPDATE_BUTTON_ROLE_NAME,
@@ -294,14 +297,13 @@ describe("タイトルの更新ボタン", () => {
     const bookmarkToSelect = mockBookmarks[1]; // Google
     await clickBookmark(bookmarkToSelect);
 
-    mockFetch.mockResolvedValueOnce({
-      ok: false, // 400の場合は false
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        isOk: false,
+        status: 400,
         message: "リクエストにIDがありませんでした。",
-      }),
-    });
+      })
+    );
 
     const updateButton = screen.getByRole("button", {
       name: UPDATE_BUTTON_ROLE_NAME,
@@ -337,14 +339,13 @@ describe("タイトルの更新ボタン", () => {
     const bookmarkToSelect = mockBookmarks[1]; // Google
     await clickBookmark(bookmarkToSelect);
 
-    mockFetch.mockResolvedValueOnce({
-      ok: false, // 400の場合は false
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        isOk: false,
+        status: 400,
         message: "IDは正の整数である必要があります。",
-      }),
-    });
+      })
+    );
 
     const updateButton = screen.getByRole("button", {
       name: UPDATE_BUTTON_ROLE_NAME,
@@ -380,14 +381,13 @@ describe("タイトルの更新ボタン", () => {
     const bookmarkToSelect = mockBookmarks[1]; // Google
     await clickBookmark(bookmarkToSelect);
 
-    mockFetch.mockResolvedValueOnce({
-      ok: false, // 500の場合は false
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      createMockResponse({
+        isOk: false,
+        status: 500,
         message: "サーバーで予期せぬエラーが発生しました。",
-      }),
-    });
+      })
+    );
 
     const updateButton = screen.getByRole("button", {
       name: UPDATE_BUTTON_ROLE_NAME,

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -157,7 +157,7 @@ export const findBookmarkWithAtLeastNKeywords = (
 
 interface CreateMockResponseOptions {
   message?: string;
-  keywordName?: string;
+  keyword_name?: string;
   isOk?: boolean;
   status?: number;
   keyword_id?: number;
@@ -166,7 +166,7 @@ interface CreateMockResponseOptions {
 
 export const createMockResponse = ({
   message,
-  keywordName,
+  keyword_name,
   isOk,
   status,
   keyword_id,
@@ -176,20 +176,25 @@ export const createMockResponse = ({
   const response: {
     ok: boolean;
     status: number;
-    json?: () => Promise<MockResponseJson>;
+    json?: () => Promise<Partial<MockResponseJson>>;
   } = {
-    ok: isOk ?? true,
+    ok: isOk ?? (responseStatus >= 200 && responseStatus < 300),
     status: responseStatus,
   };
 
   // 204 No Contentのようなボディを持たないレスポンスを考慮
   if (responseStatus !== 204) {
-    response.json = async (): Promise<MockResponseJson> => ({
-      message: message ?? "",
-      keyword_id: keyword_id ?? 1,
-      bookmark_keyword_id: bookmark_keyword_id ?? 123,
-      keyword_name: keywordName ?? "",
-    });
+    const body: Partial<MockResponseJson> = {};
+    if (message !== undefined) {
+      body.message = message;
+    }
+    // キーワード成功応答の場合のみ、関連フィールドを追加
+    if (keyword_name !== undefined) {
+      body.keyword_name = keyword_name;
+      body.keyword_id = keyword_id ?? 1;
+      body.bookmark_keyword_id = bookmark_keyword_id ?? 123;
+    }
+    response.json = async () => body;
   }
 
   return response;

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -7,6 +7,14 @@ import { FORM_BOOKMARK_DETAIL, TITLE_ROLE_NAME, URL_ROLE_NAME } from "../constan
 import { Bookmark } from "../types/Bookmark";
 import { Keyword } from "../types/Keyword";
 
+/** モックレスポンスのJSONボディの型 */
+interface MockResponseJson {
+  message: string;
+  keyword_id: number;
+  bookmark_keyword_id: number;
+  keyword_name: string;
+}
+
 export function createBookmark({
   bookmark_id = 0,
   url = "",
@@ -147,20 +155,42 @@ export const findBookmarkWithAtLeastNKeywords = (
   return bookmarkToSelect;
 };
 
-export const createMockResponse = (
-  message: string,
-  keywordName: string,
-  options: {
-    keyword_id?: number;
-    bookmark_keyword_id?: number;
-  } = {}
-) => ({
-  ok: true,
-  status: 201,
-  json: async () => ({
-    message: message,
-    keyword_id: options.keyword_id ?? 1,
-    bookmark_keyword_id: options.bookmark_keyword_id ?? 123,
-    keyword_name: keywordName,
-  }),
-});
+interface CreateMockResponseOptions {
+  message?: string;
+  keywordName?: string;
+  isOk?: boolean;
+  status?: number;
+  keyword_id?: number;
+  bookmark_keyword_id?: number;
+}
+
+export const createMockResponse = ({
+  message,
+  keywordName,
+  isOk,
+  status,
+  keyword_id,
+  bookmark_keyword_id,
+}: CreateMockResponseOptions = {}) => {
+  const responseStatus = status ?? 201;
+  const response: {
+    ok: boolean;
+    status: number;
+    json?: () => Promise<MockResponseJson>;
+  } = {
+    ok: isOk ?? true,
+    status: responseStatus,
+  };
+
+  // 204 No Contentのようなボディを持たないレスポンスを考慮
+  if (responseStatus !== 204) {
+    response.json = async (): Promise<MockResponseJson> => ({
+      message: message ?? "",
+      keyword_id: keyword_id ?? 1,
+      bookmark_keyword_id: bookmark_keyword_id ?? 123,
+      keyword_name: keywordName ?? "",
+    });
+  }
+
+  return response;
+};

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -146,3 +146,21 @@ export const findBookmarkWithAtLeastNKeywords = (
   }
   return bookmarkToSelect;
 };
+
+export const createMockResponse = (
+  message: string,
+  keywordName: string,
+  options: {
+    keyword_id?: number;
+    bookmark_keyword_id?: number;
+  } = {}
+) => ({
+  ok: true,
+  status: 201,
+  json: async () => ({
+    message: message,
+    keyword_id: options.keyword_id ?? 1,
+    bookmark_keyword_id: options.bookmark_keyword_id ?? 123,
+    keyword_name: keywordName,
+  }),
+});

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -10,9 +10,9 @@ import { Keyword } from "../types/Keyword";
 /** モックレスポンスのJSONボディの型 */
 interface MockResponseJson {
   message: string;
-  keyword_id: number;
-  bookmark_keyword_id: number;
-  keyword_name: string;
+  keyword_id?: number;
+  bookmark_keyword_id?: number;
+  keyword_name?: string;
 }
 
 export function createBookmark({

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -172,6 +172,8 @@ export const createMockResponse = ({
   keyword_id,
   bookmark_keyword_id,
 }: CreateMockResponseOptions = {}) => {
+  const DEFAULT_KEYWORD_ID = 1;
+  const DEFAULT_BOOKMARK_KEYWORD_ID = 123;
   const responseStatus = status ?? 201;
   const response: {
     ok: boolean;
@@ -191,8 +193,8 @@ export const createMockResponse = ({
     // キーワード成功応答の場合のみ、関連フィールドを追加
     if (keyword_name !== undefined) {
       body.keyword_name = keyword_name;
-      body.keyword_id = keyword_id ?? 1;
-      body.bookmark_keyword_id = bookmark_keyword_id ?? 123;
+      body.keyword_id = keyword_id ?? DEFAULT_KEYWORD_ID;
+      body.bookmark_keyword_id = bookmark_keyword_id ?? DEFAULT_BOOKMARK_KEYWORD_ID;
     }
     response.json = async () => body;
   }


### PR DESCRIPTION
### 概要
テストコード内で重複していた fetch APIのモックレスポンス生成処理を、共通のヘルパー関数にリファクタリングしました。 これにより、テストコードの可読性、保守性、一貫性を向上させることを目的としています。

### 変更内容
- モックレスポンス生成ヘルパーの作成と汎用化

  - [src/app/test-utils/bookmarkTestUtils.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/test-utils/bookmarkTestUtils.tsx) に、fetch のモックレスポンスを生成する createMockResponse ヘルパー関数を導入しました。
  - 当初はキーワード追加の成功レスポンスに特化していましたが、ステータスコード、成功フラグ (ok)、レスポンスボディなどを柔軟に設定できるよう汎用化しました。
  - これにより、204 No Content や 4xx/5xx 系のエラーレスポンスなど、様々なシナリオのモックを簡単かつ一貫した方法で作成できます。

- 既存テストのリファクタリング

  - [keyword.add.test.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/components/BookmarkManager/keyword.add.test.tsx), [delete.test.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/components/BookmarkManager/delete.test.tsx), [update.test.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/components/BookmarkManager/update.test.tsx) 内で個別に定義されていた fetch モックを、新しい createMockResponse ヘルパー関数を利用するように統一しました。

### 期待される効果
- コードの重複削減: 各テストファイルで記述されていたモックレスポンスの定型コードが集約され、テスト全体のコード量が削減されました。
- 可読性と保守性の向上: モック生成のロジックが共通化されたことで、各テストの意図がより明確になり、将来の仕様変更にも対応しやすくなりました。
- 一貫性の確保: プロジェクト全体で fetch モックの作成方法が統一され、テストコードの品質が向上しました。