### PR TITLE
refactor(components): KeywordTableのPropsを分離しデフォルト値を設定

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/components/KeywordTable.tsx
+++ b/src/app/components/KeywordTable.tsx
@@ -2,10 +2,12 @@ import React from "react";
 
 import { Keyword } from "../types/Keyword";
 
-export const KeywordTable: React.FC<{
+type KeywordTableProps = {
   keywords?: Keyword[];
   className?: string;
-}> = ({ keywords, className }) => {
+};
+
+export const KeywordTable: React.FC<KeywordTableProps> = ({ keywords = [], className }) => {
   return (
     <table aria-label="キーワードのテーブル" className={className}>
       <thead className="sr-only">
@@ -14,7 +16,7 @@ export const KeywordTable: React.FC<{
         </tr>
       </thead>
       <tbody>
-        {(keywords || []).map((keyword) => (
+        {keywords.map((keyword) => (
           <tr key={keyword.keyword_id}>
             <td className="p-1 text-sm border border-gray-700 bg-gray-100 text-gray-900">
               {keyword.keyword_name}


### PR DESCRIPTION
## 概要
KeywordTableコンポーネントのリファクタリングを実施しました。主な変更点は以下の通りです。

1. Propsの型定義を分離: コンポーネントのPropsの型定義を、インラインからKeywordTablePropsという独立した型に分離しました。これにより、コンポーネントのシグネチャが明確になり、コードの可読性と保守性が向上します。

2. keywordsプロパティにデフォルト値を設定: 分割代入を利用してkeywordsプロパティにデフォルト値として空の配列([])を設定しました。これにより、keywordsがundefinedの場合でもコンポーネントが安全に動作し、呼び出し側でのnullチェックや、コンポーネント内部での || [] のようなフォールバック処理が不要になります。

## 変更内容
以下に具体的なコードの変更差分を示します。

```typescript

import { Keyword } from "../types/Keyword";

export const KeywordTable: React.FC<{
  keywords: Keyword[];
}> = ({ keywords }) => {
type KeywordTableProps = {
  keywords?: Keyword[];
};

export const KeywordTable: React.FC<KeywordTableProps> = ({ keywords = [] }) => {
  return (
    <table aria-label="キーワードのテーブル">
    <table aria-label="キーワードのテーブル" className="mt-2">
      <thead className="sr-only">
        <tr>
          <th scope="col">キーワード</th>
```

## 期待される効果
- コードのクリーン化: コンポーネントの定義がよりシンプルでモダンになります。
- 可読性の向上: Propsの型が明確になることで、コンポーネントの利用方法が理解しやすくなります。
- 堅牢性の向上: keywordsプロパティが渡されない場合でも、デフォルト値によりエラーを防ぎます。

この変更は、バージョン1.12.1の一部として含まれます。

ご確認のほど、よろしくお願いいたします。