### PR TITLE
refactor(test): テストヘルパー関数 clickBookmark の堅牢性とデバッグ容易性を向上

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.12.6",
+      "version": "1.12.7",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/components/BookmarkManager/select.test.tsx
+++ b/src/app/components/BookmarkManager/select.test.tsx
@@ -54,7 +54,7 @@ describe("ブックマークの選択", () => {
       title: "bad title",
     });
     await expect(clickBookmark(user, bookmarkToSelect)).rejects.toThrow(
-      `ブックマーク "${bookmarkToSelect.title}" のテーブル行のクリック処理中にエラーが発生しました。`
+      `ブックマーク "${bookmarkToSelect.title}" の選択処理中にエラーが発生しました。`
     );
   });
 });

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event";
 
 import { BookmarkManager } from "../components/BookmarkManager";
@@ -65,20 +65,33 @@ export const assertNoBookmarkIsSelected = async () => {
   });
 };
 
+export const getCellWithTitle = (title: string) => {
+  const table = screen.getByRole("table", { name: "bookmarks" });
+
+  const cellWithTitle = within(table).getByText(title);
+  return cellWithTitle;
+};
+
 export const clickBookmark = async (user: UserEvent, bookmark: Bookmark) => {
   // クリックするブックマークを選択（例：2番目のブックマーク）
   // const bookmark = mockBookmarks[1]; // Google
   try {
-    const cellWithTitle = screen.getByText(bookmark.title);
+    const cellWithTitle = getCellWithTitle(bookmark.title);
+    const row = cellWithTitle.closest("tr");
+    if (!row) {
+      throw new Error(`ブックマーク "${bookmark.title}" のテーブル行が見つかりませんでした。`);
+    }
 
     // テーブル行のクリックをシミュレート
     await user.click(cellWithTitle);
     await assertBookmarkIsSelected(bookmark);
   } catch (error) {
     // エラーメッセージに元のエラーを含めるとデバッグが容易になります
-    console.error(error); // 元のエラーをログに出力
+    // console.error(error); // 元のエラーをログに出力
     throw new Error(
-      `ブックマーク "${bookmark.title}" のテーブル行のクリック処理中にエラーが発生しました。`
+      `ブックマーク "${bookmark.title}" のテーブル行のクリック処理中にエラーが発生しました。: ${
+        error instanceof Error ? error.message : String(error)
+      }`
     );
   }
 };

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -85,10 +85,9 @@ export const clickBookmark = async (user: UserEvent, bookmark: Bookmark) => {
     // テーブル行のクリックをシミュレート
     await user.click(row);
   } catch (error) {
-    throw new Error(
-      `ブックマーク "${bookmark.title}" のテーブル行のクリック処理中にエラーが発生しました。`,
-      { cause: error }
-    );
+    throw new Error(`ブックマーク "${bookmark.title}" の選択処理中にエラーが発生しました。`, {
+      cause: error,
+    });
   }
   await assertBookmarkIsSelected(bookmark);
 };

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -84,13 +84,13 @@ export const clickBookmark = async (user: UserEvent, bookmark: Bookmark) => {
 
     // テーブル行のクリックをシミュレート
     await user.click(row);
-    await assertBookmarkIsSelected(bookmark);
   } catch (error) {
     throw new Error(
       `ブックマーク "${bookmark.title}" のテーブル行のクリック処理中にエラーが発生しました。`,
       { cause: error }
     );
   }
+  await assertBookmarkIsSelected(bookmark);
 };
 
 export const mockKeywords: Keyword[] = [

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -83,7 +83,7 @@ export const clickBookmark = async (user: UserEvent, bookmark: Bookmark) => {
     }
 
     // テーブル行のクリックをシミュレート
-    await user.click(cellWithTitle);
+    await user.click(row);
     await assertBookmarkIsSelected(bookmark);
   } catch (error) {
     throw new Error(

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -86,12 +86,9 @@ export const clickBookmark = async (user: UserEvent, bookmark: Bookmark) => {
     await user.click(cellWithTitle);
     await assertBookmarkIsSelected(bookmark);
   } catch (error) {
-    // エラーメッセージに元のエラーを含めるとデバッグが容易になります
-    // console.error(error); // 元のエラーをログに出力
     throw new Error(
-      `ブックマーク "${bookmark.title}" のテーブル行のクリック処理中にエラーが発生しました。: ${
-        error instanceof Error ? error.message : String(error)
-      }`
+      `ブックマーク "${bookmark.title}" のテーブル行のクリック処理中にエラーが発生しました。`,
+      { cause: error }
     );
   }
 };

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -68,7 +68,7 @@ export const assertNoBookmarkIsSelected = async () => {
 export const getCellWithTitle = (title: string) => {
   const table = screen.getByRole("table", { name: "bookmarks" });
 
-  const cellWithTitle = within(table).getByText(title);
+  const cellWithTitle = within(table).getByRole("cell", { name: title });
   return cellWithTitle;
 };
 


### PR DESCRIPTION
テストの安定性とデバッグのしやすさを向上させるため、テストユーティリティ関数 clickBookmark をリファクタリングしました。

### 主な変更点
- セレクタの精度向上: within を使用して検索範囲をブックマークテーブル内に限定し、意図しない要素との衝突を回避するようにしました。
- 堅牢性の向上: クリック対象のテーブル行（<tr>）が確実に存在することを検証するチェックを追加しました。
- デバッグの容易化: エラーハンドリングを改善し、Error コンストラクタの cause オプションを利用して元のエラー情報を保持するようにしました。これにより、テスト失敗時の根本原因の特定が容易になります。