### PR TITLE
feat(bookmark): ブックマークテーブルのaria-labelを定数化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.12.7",
+      "version": "1.12.8",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -6,7 +6,7 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 
 import { BOOKMARKS_ENDPOINT } from "../../constants/apiEndpoints";
-import { UPDATE_BUTTON_ROLE_NAME } from "../../constants/constants";
+import { TABLE_NAME_BOOKMARKS, UPDATE_BUTTON_ROLE_NAME } from "../../constants/constants";
 import {
   clickBookmark,
   createBookmark,
@@ -152,7 +152,7 @@ describe("タイトルの更新ボタン", () => {
           buttonName: UPDATE_BUTTON_ROLE_NAME,
         });
         // リスト上の元のブックマークが消えていないことを確認
-        const table = screen.getByRole("table", { name: "bookmarks" });
+        const table = screen.getByRole("table", { name: TABLE_NAME_BOOKMARKS });
         const bookmark = within(table).getByText(bookmarkToSelect.title);
         expect(bookmark).toBeInTheDocument();
       });

--- a/src/app/components/BookmarkTable.test.tsx
+++ b/src/app/components/BookmarkTable.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { render, screen, within } from "@testing-library/react";
 
+import { TABLE_NAME_BOOKMARKS } from "../constants/constants";
 import { mockBookmarks } from "../test-utils/bookmarkTestUtils";
 import { BookmarkTable } from "./BookmarkTable";
 
@@ -18,7 +19,7 @@ describe("BookmarkTableのテスト", () => {
       />
     );
 
-    const table = screen.getByRole("table", { name: "bookmarks" });
+    const table = screen.getByRole("table", { name: TABLE_NAME_BOOKMARKS });
     expect(table).toBeInTheDocument();
 
     const headers = within(table).getAllByRole("columnheader");

--- a/src/app/components/BookmarkTable.tsx
+++ b/src/app/components/BookmarkTable.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { TABLE_NAME_BOOKMARKS } from "../constants/constants";
 import { Bookmark } from "../types/Bookmark";
 
 type BookmarkTableProps = {
@@ -16,7 +17,7 @@ export const BookmarkTable = ({
   className = "",
 }: BookmarkTableProps): React.ReactElement => {
   return (
-    <table aria-label="bookmarks" className={className}>
+    <table aria-label={TABLE_NAME_BOOKMARKS} className={className}>
       <thead>
         <tr>
           <th

--- a/src/app/constants/constants.ts
+++ b/src/app/constants/constants.ts
@@ -10,3 +10,5 @@ export const FIELDSET_KEYWORD_LABEL = "キーワード入力";
 export const KEYWORD_ROLE_NAME = "キーワード";
 export const ADD_BUTTON_ROLE_NAME = "追加";
 export const TABLE_NAME_KEYWORD = "キーワードのテーブル";
+
+export const TABLE_NAME_BOOKMARKS = "bookmarks";

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -4,7 +4,12 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event";
 
 import { BookmarkManager } from "../components/BookmarkManager";
-import { FORM_BOOKMARK_DETAIL, TITLE_ROLE_NAME, URL_ROLE_NAME } from "../constants/constants";
+import {
+  FORM_BOOKMARK_DETAIL,
+  TABLE_NAME_BOOKMARKS,
+  TITLE_ROLE_NAME,
+  URL_ROLE_NAME,
+} from "../constants/constants";
 import { Bookmark } from "../types/Bookmark";
 import { Keyword } from "../types/Keyword";
 
@@ -66,7 +71,7 @@ export const assertNoBookmarkIsSelected = async () => {
 };
 
 export const getCellWithTitle = (title: string) => {
-  const table = screen.getByRole("table", { name: "bookmarks" });
+  const table = screen.getByRole("table", { name: TABLE_NAME_BOOKMARKS });
 
   const cellWithTitle = within(table).getByRole("cell", { name: title });
   return cellWithTitle;


### PR DESCRIPTION
## 概要

`BookmarkTable` コンポーネントおよび関連するテストコードで使用されていた `aria-label` のマジックストリング `"bookmarks"` を `TABLE_NAME_BOOKMARKS` 定数として定義し、置き換えることで、コードの保守性と一貫性を向上させます。

## 変更の背景

現在、`BookmarkTable.tsx` とテストユーティリティ `bookmarkTestUtils.tsx` の両方で、テーブルを識別するための `aria-label` として `"bookmarks"` という文字列が直接記述されていました。

このアプローチには、将来的にラベル名を変更する際に複数箇所を修正する必要があり、修正漏れやタイポのリスクがあるという問題がありました。

## 変更内容

このプルリクエストでは、以下の変更を行いました。

1.  `src/app/constants/constants.ts` に `TABLE_NAME_BOOKMARKS` 定数を追加。
2.  `BookmarkTable` コンポーネントで、ハードコードされていた `aria-label` を新しい定数に置き換え。
3.  `bookmarkTestUtils.tsx` の `getCellWithTitle` ヘルパー関数内でも同様に、定数を使用するように変更。

## 期待される効果
- 保守性の向上: aria-label の値を一元管理できるため、将来の変更が容易かつ安全になります。
- 一貫性の確保: コンポーネントとテストで同じ値を使用することが保証されます。
- 可読性の向上: 定数名によって、その文字列が何を表しているのかが明確になります。