### PR TITLE
refactor(test): アサーションを toBeInTheDocument から toBeVisible に変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.12.8",
+  "version": "1.12.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.12.8",
+      "version": "1.12.9",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.12.8",
+  "version": "1.12.9",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/components/BookmarkManager/delete.test.tsx
+++ b/src/app/components/BookmarkManager/delete.test.tsx
@@ -69,7 +69,7 @@ describe("削除ボタン", () => {
         const deleteButton = screen.getByRole("button", {
           name: DELETE_BUTTON_ROLE_NAME,
         });
-        expect(deleteButton).toBeInTheDocument();
+        expect(deleteButton).toBeVisible();
       });
     });
 
@@ -119,8 +119,8 @@ describe("削除ボタン", () => {
           "ブックマークの削除中にエラーが発生しました。"
         );
         // 削除操作のコンテキスト（選択されたブックマークのタイトルや削除ボタン）が依然として表示されていることを確認
-        expect(screen.getByText(bookmarkToSelect.title)).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: DELETE_BUTTON_ROLE_NAME })).toBeInTheDocument();
+        expect(screen.getByText(bookmarkToSelect.title)).toBeVisible();
+        expect(screen.getByRole("button", { name: DELETE_BUTTON_ROLE_NAME })).toBeVisible();
       });
     });
   });

--- a/src/app/components/BookmarkManager/keyword.add.test.tsx
+++ b/src/app/components/BookmarkManager/keyword.add.test.tsx
@@ -32,7 +32,7 @@ const addNewKeyword = async (user: UserEvent, keyword: string) => {
 
 const expectTableRows = async (expectRows: number) => {
   const keywordTable = screen.getByRole("table", { name: TABLE_NAME_KEYWORD });
-  expect(keywordTable).toBeInTheDocument();
+  expect(keywordTable).toBeVisible();
   const rows = within(keywordTable).queryAllByRole("row");
   expect(rows).toHaveLength(expectRows);
 };
@@ -42,7 +42,7 @@ const expectRowsAndKeyword = async (expectRows: number, expectKeyword: string) =
     const keywordTable = screen.getByRole("table", { name: TABLE_NAME_KEYWORD });
     const keywordInput = screen.getByRole("textbox", { name: KEYWORD_ROLE_NAME });
 
-    expect(keywordTable).toBeInTheDocument();
+    expect(keywordTable).toBeVisible();
     const rows = within(keywordTable).queryAllByRole("row");
     expect(rows).toHaveLength(expectRows);
     expect(within(rows[1]).getByRole("cell")).toHaveTextContent(expectKeyword);

--- a/src/app/components/BookmarkManager/keyword.view.test.tsx
+++ b/src/app/components/BookmarkManager/keyword.view.test.tsx
@@ -77,14 +77,14 @@ describe("キーワード詳細フォームの表示のテスト", () => {
       const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(mockBookmarksWithKeywords);
       await clickBookmark(user, bookmarkToSelect);
 
-      expect(screen.getByRole("group", { name: FIELDSET_KEYWORD_LABEL })).toBeInTheDocument();
+      expect(screen.getByRole("group", { name: FIELDSET_KEYWORD_LABEL })).toBeVisible();
 
       const keywordInput = screen.getByRole("textbox", { name: KEYWORD_ROLE_NAME });
-      expect(keywordInput).toBeInTheDocument();
+      expect(keywordInput).toBeVisible();
       expect(keywordInput).toHaveValue("");
 
       const addButton = screen.getByRole("button", { name: ADD_BUTTON_ROLE_NAME });
-      expect(addButton).toBeInTheDocument();
+      expect(addButton).toBeVisible();
       expect(addButton).toBeEnabled();
     });
 

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -68,7 +68,7 @@ describe("タイトルの更新ボタン", () => {
         const updateButton = screen.getByRole("button", {
           name: UPDATE_BUTTON_ROLE_NAME,
         });
-        expect(updateButton).toBeInTheDocument();
+        expect(updateButton).toBeVisible();
       });
     });
 
@@ -154,7 +154,7 @@ describe("タイトルの更新ボタン", () => {
         // リスト上の元のブックマークが消えていないことを確認
         const table = screen.getByRole("table", { name: TABLE_NAME_BOOKMARKS });
         const bookmark = within(table).getByText(bookmarkToSelect.title);
-        expect(bookmark).toBeInTheDocument();
+        expect(bookmark).toBeVisible();
       });
     });
 

--- a/src/app/components/BookmarkManager/view.test.tsx
+++ b/src/app/components/BookmarkManager/view.test.tsx
@@ -25,7 +25,7 @@ describe("BookmarkManagerの表示を確認", () => {
     render(<BookmarkManager />);
 
     const bm = await screen.findByText("Amazon");
-    expect(bm).toBeInTheDocument();
+    expect(bm).toBeVisible();
   });
 
   it("ローディング中にローディングメッセージが表示されること", () => {

--- a/src/app/components/BookmarkTable.test.tsx
+++ b/src/app/components/BookmarkTable.test.tsx
@@ -20,7 +20,7 @@ describe("BookmarkTableのテスト", () => {
     );
 
     const table = screen.getByRole("table", { name: TABLE_NAME_BOOKMARKS });
-    expect(table).toBeInTheDocument();
+    expect(table).toBeVisible();
 
     const headers = within(table).getAllByRole("columnheader");
     expect(headers).toHaveLength(1);
@@ -70,7 +70,7 @@ describe("BookmarkTableのテスト", () => {
     );
 
     const table = screen.getByRole("table");
-    expect(table).toBeInTheDocument();
+    expect(table).toBeVisible();
 
     const rows = screen.queryAllByRole("row");
     expect(rows).toHaveLength(1); // ヘッダー行のみ

--- a/src/app/components/ErrorMessage.test.tsx
+++ b/src/app/components/ErrorMessage.test.tsx
@@ -48,7 +48,7 @@ describe("ErrorMessage", () => {
     const errorMessageElement = screen.getByTestId("bookmark-message");
     expect(errorMessageElement).toHaveTextContent("エラーが発生しました");
     expect(errorMessageElement).toHaveClass("text-red-500");
-    expect(screen.getByRole("button", { name: "閉じる" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "閉じる" })).toBeVisible();
   });
 
   it("should call handleErrorClose when close button is clicked", async () => {

--- a/src/app/components/KeywordTable.test.tsx
+++ b/src/app/components/KeywordTable.test.tsx
@@ -14,7 +14,7 @@ describe("KeywordTableのテスト", () => {
   it("キーワードのリストが空の場合、ヘッダー行のみ表示されデータ行は表示されない", () => {
     render(<KeywordTable keywords={[]} />);
     const keywordTable = screen.getByRole("table", { name: "キーワードのテーブル" });
-    expect(keywordTable).toBeInTheDocument();
+    expect(keywordTable).toBeVisible();
 
     const rows = screen.queryAllByRole("row");
     expect(rows).toHaveLength(1); // ヘッダー行のみ

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -24,7 +24,7 @@ describe("テスト環境を動作確認するためのサンプルのテスト"
     render(<Home />);
     const urlInput = await screen.findByText("kubotama/linkpage");
     const titleInput = await screen.findByText("Google");
-    expect(urlInput).toBeInTheDocument();
-    expect(titleInput).toBeInTheDocument();
+    expect(urlInput).toBeVisible();
+    expect(titleInput).toBeVisible();
   });
 });

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -262,7 +262,7 @@ export const expectBookmarkFormValues = async (values: {
     const button = screen.getByRole("button", {
       name: values.buttonName,
     });
-    expect(button).toBeInTheDocument();
+    expect(button).toBeVisible();
   }
 };
 
@@ -286,7 +286,7 @@ export const setBookmarkFormValuesAndEnterKeydown = async (user: UserEvent, url:
 export const setupBookmarkManagerForTest = async () => {
   render(<BookmarkManager />);
   await waitFor(() => {
-    expect(screen.getByText(mockBookmarks[0].title)).toBeInTheDocument();
+    expect(screen.getByText(mockBookmarks[0].title)).toBeVisible();
   });
 };
 


### PR DESCRIPTION
## 概要
テストコードの堅牢性を向上させるため、要素の存在を検証するアサーションを toBeInTheDocument() から toBeVisible() に変更しました。

## 背景
これまでのテストでは toBeInTheDocument() を使用して、要素がDOMツリー上に存在することを確認していました。しかし、このアサーションでは display: none や visibility: hidden といったスタイルによって要素がユーザーから不可視になっているケースを検知できません。

よりユーザーの実際の操作に近い形でコンポーネントの振る舞いを保証するため、アサーションを toBeVisible() に変更し、要素が視覚的に表示されていることまでをテストの合格条件とします。

## 変更内容
- [src/app/page.test.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/page.test.tsx) 内のテストケースで、screen.findByText で取得した要素の検証を toBeInTheDocument() から toBeVisible() に変更しました。