### PR TITLE
refactor(test): expectBookmarkFormValuesを非同期対応にしテストを安定化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.12.11",
+  "version": "1.12.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.12.11",
+      "version": "1.12.12",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.12.11",
+  "version": "1.12.12",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/components/BookmarkManager/parameter.test.tsx
+++ b/src/app/components/BookmarkManager/parameter.test.tsx
@@ -52,7 +52,6 @@ describe("「パラメータ」ボタン: URLから無駄な文字列を削除�
     ])("無駄なパラメータを削除するテスト: $url", async ({ url, expectedUrl }) => {
       await setBookmarkFormValuesAndClickButton(user, { url }, PARAMETER_BUTTON_ROLE_NAME);
 
-      // TODO: #273 - フォームの状態が非同期で更新されることを考慮したアサーションに変更
       await expectBookmarkFormValues({ url: expectedUrl });
     });
   });

--- a/src/app/components/BookmarkManager/path.test.tsx
+++ b/src/app/components/BookmarkManager/path.test.tsx
@@ -66,7 +66,6 @@ describe("「←」ボタン", () => {
   ])(" URLから、/の階層を一段、削除する: $url", async ({ url, expectedUrl }) => {
     await setBookmarkFormValuesAndClickButton(user, { url }, ARROW_BUTTON_ROLE_NAME);
 
-    // TODO: #273 - フォームの状態が非同期で更新されることを考慮したアサーションに変更
     await expectBookmarkFormValues({ url: expectedUrl });
   });
 });

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -188,7 +188,7 @@ describe("タイトルの更新ボタン", () => {
 
       await clickUpdateButton(user);
 
-      // フォームにはユーザーが入力した空のタイトルが保持されるべき
+      // フォームの値は変更されずに保持されるべき
       await expectBookmarkFormValues({
         url: bookmarkToSelect.url,
         title: bookmarkToSelect.title,

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -94,12 +94,11 @@ describe("タイトルの更新ボタン", () => {
             title: updateTitle,
           }),
         });
-
-        // 画面の更新の確認;
-        // TODO: #273 - フォームの状態が非同期で更新されることを考慮したアサーションに変更
-        expectBookmarkFormValues({ url: updateUrl, title: updateTitle });
       });
       expect(await screen.findAllByText(updateTitle)).toHaveLength(1);
+
+      // 画面の更新の確認;
+      await expectBookmarkFormValues({ url: updateUrl, title: updateTitle });
 
       const updatedBookmark: Bookmark = createBookmark({
         bookmark_id: bookmarkToSelect.bookmark_id,
@@ -108,10 +107,7 @@ describe("タイトルの更新ボタン", () => {
         keywords: bookmarkToSelect.keywords,
       });
       await clickBookmark(user, updatedBookmark);
-      await waitFor(() => {
-        // TODO: #273 - フォームの状態が非同期で更新されることを考慮したアサーションに変更
-        expectBookmarkFormValues({ url: updateUrl, title: updateTitle });
-      });
+      await expectBookmarkFormValues({ url: updateUrl, title: updateTitle });
     });
 
     it("同じURLを指定された場合には409を返す。", async () => {
@@ -131,14 +127,11 @@ describe("タイトルの更新ボタン", () => {
         UPDATE_BUTTON_ROLE_NAME
       );
 
-      await waitFor(() => {
-        // TODO: #273 - フォームの状態が非同期で更新されることを考慮したアサーションに変更
-        // フォームに入力した値が保持され、更新ボタンが表示されていることを確認
-        expectBookmarkFormValues({
-          url: updateUrl,
-          title: updateTitle,
-          buttonName: UPDATE_BUTTON_ROLE_NAME,
-        });
+      // フォームに入力した値が保持され、更新ボタンが表示されていることを確認
+      await expectBookmarkFormValues({
+        url: updateUrl,
+        title: updateTitle,
+        buttonName: UPDATE_BUTTON_ROLE_NAME,
       });
       expect(await screen.findByTestId("bookmark-message")).toHaveTextContent(
         "指定されたURLのブックマークは既に登録されています。"
@@ -158,15 +151,13 @@ describe("タイトルの更新ボタン", () => {
 
       await setBookmarkFormValuesAndClickButton(user, { title: "" }, UPDATE_BUTTON_ROLE_NAME);
 
-      await waitFor(() => {
-        // TODO: #273 - フォームの状態が非同期で更新されることを考慮したアサーションに変更
-        // フォームにはユーザーが入力した空のタイトルが保持されるべき
-        expectBookmarkFormValues({
-          url: bookmarkToSelect.url,
-          title: "",
-          buttonName: UPDATE_BUTTON_ROLE_NAME,
-        });
+      // フォームにはユーザーが入力した空のタイトルが保持されるべき
+      await expectBookmarkFormValues({
+        url: bookmarkToSelect.url,
+        title: "",
+        buttonName: UPDATE_BUTTON_ROLE_NAME,
       });
+
       expect(await screen.findByTestId("bookmark-message")).toHaveTextContent(
         "ブックマークの更新中にエラーが発生しました。"
       );
@@ -197,14 +188,13 @@ describe("タイトルの更新ボタン", () => {
 
       await clickUpdateButton(user);
 
-      await waitFor(() => {
-        // TODO: #273 - フォームの状態が非同期で更新されることを考慮したアサーションに変更
-        expectBookmarkFormValues({
-          url: bookmarkToSelect.url,
-          title: bookmarkToSelect.title,
-          buttonName: UPDATE_BUTTON_ROLE_NAME,
-        });
+      // フォームにはユーザーが入力した空のタイトルが保持されるべき
+      await expectBookmarkFormValues({
+        url: bookmarkToSelect.url,
+        title: bookmarkToSelect.title,
+        buttonName: UPDATE_BUTTON_ROLE_NAME,
       });
+
       expect(await screen.findByTestId("bookmark-message")).toHaveTextContent(
         "ブックマークの更新中にエラーが発生しました。"
       );

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -257,15 +257,19 @@ export const expectBookmarkFormValues = async (values: {
   title?: string;
   buttonName?: string;
 }) => {
+  const promises: Promise<unknown>[] = [];
+
   if (values.url !== undefined) {
-    await assertHaveValueByRole("textbox", URL_ROLE_NAME, values.url);
+    promises.push(assertHaveValueByRole("textbox", URL_ROLE_NAME, values.url));
   }
   if (values.title !== undefined) {
-    await assertHaveValueByRole("textbox", TITLE_ROLE_NAME, values.title);
+    promises.push(assertHaveValueByRole("textbox", TITLE_ROLE_NAME, values.title));
   }
   if (values.buttonName !== undefined) {
-    await screen.findByRole("button", { name: values.buttonName });
+    promises.push(screen.findByRole("button", { name: values.buttonName }));
   }
+
+  await Promise.all(promises);
 };
 
 export const keyDown = async (user: UserEvent, key: string) => {

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -245,24 +245,26 @@ export const setBookmarkFormValuesAndClickButton = async (
   }
 };
 
+const assertHaveValueByRole = async (roleName: string, name: string, value: string) => {
+  await waitFor(() => {
+    const element = screen.getByRole(roleName, { name });
+    expect(element).toHaveValue(value);
+  });
+};
+
 export const expectBookmarkFormValues = async (values: {
   url?: string;
   title?: string;
   buttonName?: string;
 }) => {
   if (values.url !== undefined) {
-    const urlInput = screen.getByRole("textbox", { name: URL_ROLE_NAME });
-    expect(urlInput).toHaveValue(values.url);
+    await assertHaveValueByRole("textbox", URL_ROLE_NAME, values.url);
   }
   if (values.title !== undefined) {
-    const titleInput = screen.getByRole("textbox", { name: TITLE_ROLE_NAME });
-    expect(titleInput).toHaveValue(values.title);
+    await assertHaveValueByRole("textbox", TITLE_ROLE_NAME, values.title);
   }
   if (values.buttonName !== undefined) {
-    const button = screen.getByRole("button", {
-      name: values.buttonName,
-    });
-    expect(button).toBeVisible();
+    await screen.findByRole("button", { name: values.buttonName });
   }
 };
 


### PR DESCRIPTION
## 概要
テストの安定性を向上させるため、テストヘルパー関数 expectBookmarkFormValues をリファクタリングし、フォームの値が非同期で更新されるのを待機するように変更しました。

これにより、フォームの状態変更を伴うテストにおいて、waitFor を個別に使用する必要がなくなり、よりクリーンで信頼性の高いテストコードを記述できるようになります。

## 変更内容
- waitFor を内包した新しい内部ヘルパー関数 assertHaveValueByRole を追加しました。
- expectBookmarkFormValues 内で、assertHaveValueByRole と findByRole を使用するように変更し、アサーションが非同期で実行されるようにしました。
- このリファクタリングに伴い、[parameter.test.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/components/BookmarkManager/parameter.test.tsx) と [path.test.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/components/BookmarkManager/path.test.tsx) から不要になった TODO コメントを削除しました。

## 関連イシュー
Fixes #273