### PR TITLE
refactor(test-utils): テキストボックス入力処理を共通関数に切り出し

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.12.12",
+  "version": "1.12.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.12.12",
+      "version": "1.12.13",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.12.12",
+  "version": "1.12.13",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -215,6 +215,14 @@ export const createMockResponse = ({
   return response;
 };
 
+const typeInTextbox = async (user: UserEvent, name: string, value: string) => {
+  const textbox = screen.getByRole("textbox", { name });
+  await user.clear(textbox);
+  if (value.length > 0) {
+    await user.type(textbox, value);
+  }
+};
+
 export const setBookmarkFormValuesAndClickButton = async (
   user: UserEvent,
   values: {
@@ -224,24 +232,13 @@ export const setBookmarkFormValuesAndClickButton = async (
   buttonName?: string
 ) => {
   if (values.url !== undefined) {
-    const urlInput = screen.getByRole("textbox", { name: URL_ROLE_NAME });
-    await user.clear(urlInput);
-    if (values.url.length !== 0) {
-      await user.type(urlInput, values.url);
-    }
+    await typeInTextbox(user, URL_ROLE_NAME, values.url);
   }
   if (values.title !== undefined) {
-    const titleInput = screen.getByRole("textbox", { name: TITLE_ROLE_NAME });
-    await user.clear(titleInput);
-    if (values.title.length !== 0) {
-      await user.type(titleInput, values.title);
-    }
+    await typeInTextbox(user, TITLE_ROLE_NAME, values.title);
   }
   if (buttonName !== undefined) {
-    const button = screen.getByRole("button", {
-      name: buttonName,
-    });
-    await user.click(button);
+    await user.click(screen.getByRole("button", { name: buttonName }));
   }
 };
 


### PR DESCRIPTION
## 概要
テストユーティリティファイル [bookmarkTestUtils.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/test-utils/bookmarkTestUtils.tsx) 内で、複数の箇所で利用されていたテキストボックスへの入力処理（クリアしてから新しい値を入力するロジック）を、新しい共通関数 typeInTextbox として切り出しました。 setBookmarkFormValuesAndClickButton 関数がこの新しい共通関数を利用するようにリファクタリングしています。

## 変更理由
- テストコード内のロジックの重複を排除し、コードのDRY (Don't Repeat Yourself) 原則を徹底するため。
- 可読性と保守性を向上させ、今後のテストコードのメンテナンスを容易にするため。

Fixes #261 