### PR TITLE
feat(api): APIエラーハンドリング用のユーティリティを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,11 +350,26 @@ npm run start
 linkpage はリンクデータを SQLite のデータベースで管理します。基本的な構造は以下の通りです：
 
 ```SQL
-    CREATE TABLE IF NOT EXISTS bookmarks (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      url TEXT NOT NULL UNIQUE,
-      title TEXT NOT NULL
-    )
+  CREATE TABLE IF NOT EXISTS bookmarks (
+    bookmark_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    url TEXT NOT NULL UNIQUE,
+    title TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS keywords (
+    keyword_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    keyword_name TEXT NOT NULL UNIQUE
+  );
+  CREATE TABLE IF NOT EXISTS bookmark_keywords (
+    bookmark_keyword_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    bookmark_id INTEGER,
+    keyword_id INTEGER,
+    FOREIGN KEY (bookmark_id) REFERENCES bookmarks(bookmark_id) ON DELETE CASCADE,
+    FOREIGN KEY (keyword_id) REFERENCES keywords(keyword_id) ON DELETE CASCADE,
+    UNIQUE (bookmark_id, keyword_id)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_bookmark_keywords_keyword_id ON bookmark_keywords(keyword_id);
+  CREATE INDEX IF NOT EXISTS idx_bookmark_keywords_bookmark_id_keyword_id ON bookmark_keywords(bookmark_id, keyword_id);
 ```
 
 ## ブックマーク機能

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.12.16",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.12.16",
+      "version": "1.13.0",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.12.16",
+  "version": "1.13.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/utils/ApiUtils.ts
+++ b/src/app/api/utils/ApiUtils.ts
@@ -1,0 +1,61 @@
+import type { ApiErrorResponse } from "@/app/types/ApiResponse";
+
+/**
+ * APIエラーを表すカスタムエラークラス。
+ * @param message - エラーメッセージ（フォーマット前）
+ * @param status - HTTPステータスコード
+ */
+export class ApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number, options?: { cause: unknown }) {
+    // 親クラスのErrorには、元のメッセージをそのまま渡す
+    super(message, options);
+    this.name = "ApiError";
+    this.status = status;
+  }
+
+  // エラーオブジェクトが文字列として評価される際に、ステータスコードを含む形式にする
+  public toString(): string {
+    return `ApiError: [${this.status}] ${this.message}`;
+  }
+
+  /**
+   * エラーオブジェクトをJSONにシリアライズする際に使用されるメソッド。
+   * @returns シリアライズ可能なエラー情報オブジェクト
+   */
+  public toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      status: this.status,
+    };
+  }
+}
+
+/**
+ * APIからのエラーレスポンスを解析し、ApiErrorオブジェクトを生成します。
+ * この関数は、`response.ok`が`false`であるようなエラーレスポンスを処理することを想定しています。
+ * @param response - fetchからのResponseオブジェクト
+ * @returns ApiErrorオブジェクトを含むPromise
+ */
+export const parseApiError = async (response: Response): Promise<ApiError> => {
+  let message = `リクエストに失敗しました。ステータス: ${response.status} ${response.statusText}`;
+  let cause: unknown;
+  try {
+    const json: ApiErrorResponse = await response.json();
+    if (json && typeof json.message === "string") {
+      message = json.message;
+    } else {
+      // messageフィールドがない場合も警告ログを出力
+      console.warn("APIエラーレスポンスのボディに message フィールドが含まれていません。", json);
+    }
+  } catch (e: unknown) {
+    cause = e;
+    // JSONのパースに失敗した場合でもエラーとして扱えるように、
+    // ステータスコードに基づいたフォールバックメッセージを使用します。
+    console.error("APIエラーレスポンスボディのJSONパースに失敗しました。", e);
+  }
+
+  return new ApiError(message, response.status, { cause });
+};

--- a/src/app/types/ApiResponse.ts
+++ b/src/app/types/ApiResponse.ts
@@ -1,0 +1,3 @@
+export interface ApiErrorResponse {
+  message: string;
+}


### PR DESCRIPTION
## 概要

APIからのエラーレスポンスをクライアントサイドで一貫して処理するための、新しいエラーハンドリングユーティリティを追加しました。

## 背景

これまで、クライアントサイドでのAPIエラー処理は各コンポーネントで個別に行われており、コードの重複や処理の不統一が発生する可能性がありました。
この変更により、エラーハンドリングのロジックを共通化し、コードの可読性と保守性を向上させることを目指します。

## 変更点

- **`ApiError` カスタムエラークラスの導入**: HTTPステータスコードとエラーメッセージを保持するカスタムエラークラスを導入しました。これにより、エラーの種類に応じた詳細なハンドリングが可能になります。
- **`parseApiError` ヘルパー関数の追加**: `fetch` APIのレスポンスを解析し、`ApiError`インスタンスを生成するヘルパー関数を追加しました。レスポンスボディがJSONでない場合やパースに失敗した場合でも、ステータスコードに基づいた適切なエラーを生成します。
- **`ApiErrorResponse` 型の定義**: APIから返されるエラーレスポンスのJSONボディの型を定義し、型安全性を向上させました。

## 影響範囲

この変更はクライアントサイドのユーティリティ追加であり、既存のAPIエンドポイントの動作に影響はありません。

fixes: #283 