### PR TITLE
refactor(error-handling): APIクライアントのエラーハンドリングを共通化・改善

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/utils/ApiUtils.ts
+++ b/src/app/api/utils/ApiUtils.ts
@@ -17,7 +17,7 @@ export class ApiError extends Error {
 
   // エラーオブジェクトが文字列として評価される際に、ステータスコードを含む形式にする
   public toString(): string {
-    return `ApiError: [${this.status}] ${this.message}`;
+    return `${this.name}: [${this.status}] ${this.message}`;
   }
 
   /**
@@ -30,6 +30,13 @@ export class ApiError extends Error {
       message: this.message,
       status: this.status,
     };
+  }
+}
+
+export class DuplicatedUrlError extends ApiError {
+  constructor(message: string) {
+    super(message, 409);
+    this.name = "DuplicatedUrlError";
   }
 }
 
@@ -115,6 +122,9 @@ export const parseApiError = async (response: Response): Promise<ApiError> => {
       );
       cause = createErrorCauseFromContext({ error: e, body: bodyText });
     }
+  }
+  if (response.status === 409) {
+    return new DuplicatedUrlError(message);
   }
   return new ApiError(message, response.status, { cause });
 };

--- a/src/app/api/utils/ApiUtils.ts
+++ b/src/app/api/utils/ApiUtils.ts
@@ -34,8 +34,8 @@ export class ApiError extends Error {
 }
 
 export class DuplicatedUrlError extends ApiError {
-  constructor(message: string) {
-    super(message, 409);
+  constructor(message: string, options?: { cause: unknown }) {
+    super(message, 409, options);
     this.name = "DuplicatedUrlError";
   }
 }
@@ -124,7 +124,7 @@ export const parseApiError = async (response: Response): Promise<ApiError> => {
     }
   }
   if (response.status === 409) {
-    return new DuplicatedUrlError(message);
+    return new DuplicatedUrlError(message, { cause });
   }
   return new ApiError(message, response.status, { cause });
 };

--- a/src/app/components/BookmarkManager/delete.test.tsx
+++ b/src/app/components/BookmarkManager/delete.test.tsx
@@ -107,7 +107,7 @@ describe("削除ボタン", () => {
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "ブックマークの削除エラー:",
-        `[${errorCase.status}] ${errorCase.message}`
+        `ApiError: [${errorCase.status}] ${errorCase.message}`
       );
 
       expect(await screen.findByTestId("bookmark-message")).toHaveTextContent(

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 
-import { afterEach, beforeEach, describe, expect, it, vi, MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
@@ -146,7 +146,7 @@ describe("タイトルの更新ボタン", () => {
 
         expect(consoleErrorSpy).toHaveBeenCalledWith(
           "ブックマークの更新エラー:",
-          `[${statusCode}] ${errorText}`
+          `DuplicatedUrlError: [${statusCode}] ${errorText}`
         );
 
         // フォームに入力した値が保持され、更新ボタンが表示されていることを確認
@@ -189,7 +189,7 @@ describe("タイトルの更新ボタン", () => {
 
         expect(consoleErrorSpy).toHaveBeenCalledWith(
           "ブックマークの更新エラー:",
-          `[${errorCase.status}] ${errorCase.message}`
+          `ApiError: [${errorCase.status}] ${errorCase.message}`
         );
 
         // フォームの値は変更されずに保持されるべき

--- a/src/app/components/BookmarkManager/view.test.tsx
+++ b/src/app/components/BookmarkManager/view.test.tsx
@@ -49,7 +49,6 @@ describe("BookmarkManagerの表示を確認", () => {
       ok: false,
       status: statusCode,
       headers: { "Content-Type": "application/json" },
-      json: async () => JSON.stringify({ message: errorText }),
       text: async () => JSON.stringify({ message: errorText }),
     });
 

--- a/src/app/components/BookmarkManager/view.test.tsx
+++ b/src/app/components/BookmarkManager/view.test.tsx
@@ -58,7 +58,10 @@ describe("BookmarkManagerの表示を確認", () => {
     const errorMessage = await screen.findByTestId("bookmark-message");
     expect(errorMessage).toHaveTextContent(/ブックマークのロード中にエラーが発生しました。/);
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith("ブックマークのロードエラー:", errorText);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "ブックマークのロードエラー:",
+      `ApiError: [${statusCode}] ${errorText}`
+    );
 
     consoleErrorSpy.mockRestore();
   });

--- a/src/app/components/BookmarkManager/view.test.tsx
+++ b/src/app/components/BookmarkManager/view.test.tsx
@@ -49,7 +49,8 @@ describe("BookmarkManagerの表示を確認", () => {
       ok: false,
       status: statusCode,
       headers: { "Content-Type": "application/json" },
-      json: async () => ({ message: errorText }),
+      json: async () => JSON.stringify({ message: errorText }),
+      text: async () => JSON.stringify({ message: errorText }),
     });
 
     render(<BookmarkManager />);
@@ -57,10 +58,7 @@ describe("BookmarkManagerの表示を確認", () => {
     const errorMessage = await screen.findByTestId("bookmark-message");
     expect(errorMessage).toHaveTextContent(/ブックマークのロード中にエラーが発生しました。/);
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "ブックマークのロードエラー:",
-      `[${statusCode}] ${errorText}`
-    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith("ブックマークのロードエラー:", errorText);
 
     consoleErrorSpy.mockRestore();
   });

--- a/src/app/hooks/useBookmark.ts
+++ b/src/app/hooks/useBookmark.ts
@@ -4,6 +4,7 @@ import { parseApiError } from "../api/utils/ApiUtils";
 import { BOOKMARKS_ENDPOINT } from "../constants/apiEndpoints";
 import { Bookmark } from "../types/Bookmark";
 import { Keyword } from "../types/Keyword";
+import { ApiError } from "../api/utils/ApiUtils";
 
 export class DuplicatedUrlError extends Error {
   constructor(message: string) {
@@ -11,6 +12,16 @@ export class DuplicatedUrlError extends Error {
     this.name = "DuplicatedUrlError";
   }
 }
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof ApiError) {
+    return error.toString();
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+};
 
 export const useBookmarks = () => {
   const [bookmarks, setBookmarks] = useState<Bookmark[]>([]);
@@ -26,7 +37,7 @@ export const useBookmarks = () => {
         throw await parseApiError(response);
       }
     } catch (error: unknown) {
-      console.error("ブックマークのロードエラー:", (error as Error).message);
+      console.error("ブックマークのロードエラー:", getErrorMessage(error));
       throw error;
     }
   }, []);
@@ -42,11 +53,10 @@ export const useBookmarks = () => {
           currentBookmarks.filter((bookmark) => bookmark.bookmark_id !== bookmark_id)
         );
       } else {
-        const json = await response.json();
-        throw new Error(`[${response.status}] ${json.message}`);
+        throw await parseApiError(response);
       }
     } catch (error: unknown) {
-      console.error("ブックマークの削除エラー:", (error as Error).message);
+      console.error("ブックマークの削除エラー:", getErrorMessage(error));
       throw error;
     }
   }, []);

--- a/src/app/hooks/useBookmark.ts
+++ b/src/app/hooks/useBookmark.ts
@@ -1,17 +1,9 @@
 import { useCallback, useState } from "react";
 
-import { parseApiError } from "../api/utils/ApiUtils";
+import { ApiError, parseApiError } from "../api/utils/ApiUtils";
 import { BOOKMARKS_ENDPOINT } from "../constants/apiEndpoints";
 import { Bookmark } from "../types/Bookmark";
 import { Keyword } from "../types/Keyword";
-import { ApiError } from "../api/utils/ApiUtils";
-
-export class DuplicatedUrlError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "DuplicatedUrlError";
-  }
-}
 
 const getErrorMessage = (error: unknown): string => {
   if (error instanceof ApiError) {
@@ -84,16 +76,10 @@ export const useBookmarks = () => {
           )
         );
       } else {
-        // エラーレスポンスの処理
-        const json = await response.json();
-        if (response.status === 409) {
-          throw new DuplicatedUrlError(`[${response.status}] ${json.message}`);
-        } else {
-          throw new Error(`[${response.status}] ${json.message}`);
-        }
+        throw await parseApiError(response);
       }
     } catch (error: unknown) {
-      console.error("ブックマークの更新エラー:", (error as Error).message); // 詳細なエラーはコンソールへ
+      console.error("ブックマークの更新エラー:", getErrorMessage(error)); // 詳細なエラーはコンソールへ
       throw error;
     }
   }, []);

--- a/src/app/hooks/useBookmark.ts
+++ b/src/app/hooks/useBookmark.ts
@@ -94,10 +94,7 @@ export const useBookmarks = () => {
         body: JSON.stringify({ keyword_name }),
       });
       if (!response.ok) {
-        const json = await response.json();
-        throw new Error(
-          json.message || `キーワードの追加に失敗しました。 Status: ${response.status}`
-        );
+        throw await parseApiError(response);
       }
       const responseData = await response.json();
       const newKeyword: Keyword = {
@@ -113,7 +110,7 @@ export const useBookmarks = () => {
       );
       return;
     } catch (error: unknown) {
-      console.error("キーワードの追加エラー:", (error as Error).message); // 詳細なエラーはコンソールへ
+      console.error("キーワードの追加エラー:", getErrorMessage(error)); // 詳細なエラーはコンソールへ
       throw error;
     }
   }, []);

--- a/src/app/hooks/useBookmark.ts
+++ b/src/app/hooks/useBookmark.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 
+import { parseApiError } from "../api/utils/ApiUtils";
 import { BOOKMARKS_ENDPOINT } from "../constants/apiEndpoints";
 import { Bookmark } from "../types/Bookmark";
 import { Keyword } from "../types/Keyword";
@@ -22,8 +23,7 @@ export const useBookmarks = () => {
         setBookmarks(data);
         return;
       } else {
-        const json = await response.json();
-        throw new Error(`[${response.status}] ${json.message}`);
+        throw await parseApiError(response);
       }
     } catch (error: unknown) {
       console.error("ブックマークのロードエラー:", (error as Error).message);

--- a/src/app/hooks/useBookmarkManager.ts
+++ b/src/app/hooks/useBookmarkManager.ts
@@ -3,7 +3,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
-import { DuplicatedUrlError, useBookmarks } from "./useBookmark";
+import { DuplicatedUrlError } from "../api/utils/ApiUtils";
+import { useBookmarks } from "./useBookmark";
 import { useErrorMessage } from "./useErrorMessage";
 
 export const useBookmarkManager = () => {

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -191,6 +191,7 @@ export const createMockResponse = ({
     ok: boolean;
     status: number;
     json?: () => Promise<Partial<MockResponseJson>>;
+    text?: () => Promise<string>;
   } = {
     ok: isOk ?? (responseStatus >= 200 && responseStatus < 300),
     status: responseStatus,
@@ -209,6 +210,7 @@ export const createMockResponse = ({
       body.bookmark_keyword_id = bookmark_keyword_id ?? DEFAULT_BOOKMARK_KEYWORD_ID;
     }
     response.json = async () => body;
+    response.text = async () => JSON.stringify({ message });
   }
 
   return response;

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -210,7 +210,7 @@ export const createMockResponse = ({
       body.bookmark_keyword_id = bookmark_keyword_id ?? DEFAULT_BOOKMARK_KEYWORD_ID;
     }
     response.json = async () => body;
-    response.text = async () => JSON.stringify({ message });
+    response.text = async () => JSON.stringify(body);
   }
 
   return response;


### PR DESCRIPTION
## 概要
APIクライアント側のエラーハンドリング処理をリファクタリングし、コードの保守性と一貫性を向上させます。また、特定のHTTPステータスコード（409 Conflict）に対して、より具体的で分かりやすいエラーフィードバックをユーザーに提供できるように改善します。

Fixes #284

## 変更内容
- エラー処理の共通化:

  - [ApiUtils.ts](code-assist-path:/home/user1/projects/linkpage/src/app/api/utils/ApiUtils.ts) に parseApiError ユーティリティを導入し、fetch のレスポンスから ApiError オブジェクトを生成するロジックを共通化しました。
  - useBookmark フック内の各API呼び出し (getBookmarks, deleteBookmark, updateBookmark, addKeyword) をリファクタリングし、parseApiError を利用するように変更しました。
  - エラーオブジェクトからメッセージを安全に取得するための getErrorMessage ヘルパーを導入しました。

- 専用エラークラスの導入:

  - URL重複エラー (HTTP 409) を表現するための DuplicatedUrlError クラスを ApiError のサブクラスとして定義しました。
  - parseApiError は、レスポンスのステータスコードが409の場合に DuplicatedUrlError をスローするように修正しました。

- エラー表示の改善:

  - useBookmarkManager フックで、catchしたエラーが DuplicatedUrlError かどうかを判定し、より具体的なエラーメッセージをユーザーに表示するように改善しました。
  - ApiError.toString() がハードコードされたクラス名ではなく this.name を参照するようにし、サブクラスでも正しいエラー名が表示されるように修正しました。

## 期待される効果
- コードの重複が削減され、保守性が向上します。
- エラーハンドリングのロジックが一元化され、一貫性が保たれます。
- 重複URLのような特定のエラーに対して、UIで適切なフィードバックを返すことが容易になります。