### PR TITLE
refactor(http): HTTPステータスコードを定数化しマジックナンバーを排除

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/bookmarks/[bookmark_id]/delete.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/delete.test.ts
@@ -1,6 +1,12 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  HTTP_STATUS_BAD_REQUEST,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_NO_CONTENT,
+  HTTP_STATUS_NOT_FOUND,
+} from "../../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../../test-utils/assertions";
 import { mockBookmarks } from "../../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../../test-utils/db-setup";
@@ -64,7 +70,7 @@ describe("ブックマーク削除APIのテスト (オンメモリDB)", () => {
     const response = await DELETE(request, context);
 
     // レスポンスステータスを確認 (204 No Content)
-    expect(response.status).toBe(204);
+    expect(response.status).toBe(HTTP_STATUS_NO_CONTENT);
 
     // データベースから削除されたことを確認
     const deletedEntry = selectStmt.get(bookmarkToDelete.url);
@@ -84,7 +90,11 @@ describe("ブックマーク削除APIのテスト (オンメモリDB)", () => {
     const [request, context] = createDeleteRequest(nonExistentId.toString());
     const response = await DELETE(request, context);
 
-    await assertErrorResponse(response, 404, "指定されたブックマークがありません。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_NOT_FOUND,
+      "指定されたブックマークがありません。"
+    );
 
     // ブックマーク数が変わっていないことを確認
     const count = (
@@ -103,7 +113,11 @@ describe("ブックマーク削除APIのテスト (オンメモリDB)", () => {
     const [request, context] = createDeleteRequest(anyValidId.toString());
     const response = await DELETE(request, context);
 
-    await assertErrorResponse(response, 500, "サーバー内部でエラーが発生しました。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_INTERNAL_SERVER_ERROR,
+      "サーバー内部でエラーが発生しました。"
+    );
   });
 
   it("DELETE: 不正なIDの場合には400エラーを返す", async () => {
@@ -111,6 +125,10 @@ describe("ブックマーク削除APIのテスト (オンメモリDB)", () => {
     const [request, context] = createDeleteRequest(nonExistentId.toString());
     const response = await DELETE(request, context);
 
-    await assertErrorResponse(response, 400, "IDは正の整数である必要があります。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_BAD_REQUEST,
+      "IDは正の整数である必要があります。"
+    );
   });
 });

--- a/src/app/api/bookmarks/[bookmark_id]/get.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/get.test.ts
@@ -1,6 +1,12 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  HTTP_STATUS_BAD_REQUEST,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_NOT_FOUND,
+  HTTP_STATUS_OK,
+} from "../../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../../test-utils/assertions";
 import { expectEqualBookmark, mockBookmarks } from "../../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../../test-utils/db-setup";
@@ -44,7 +50,7 @@ describe("ブックマークを1件取得するAPIのテスト", () => {
     const [request, context] = createGetRequest(targetBookmark.bookmark_id.toString());
     const response = await GET(request, context);
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(HTTP_STATUS_OK);
     const json = await response.json();
 
     expectEqualBookmark(json, targetBookmark);
@@ -54,14 +60,22 @@ describe("ブックマークを1件取得するAPIのテスト", () => {
     const [request, context] = createGetRequest("abc");
     const response = await GET(request, context);
 
-    await assertErrorResponse(response, 400, "IDは正の整数である必要があります。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_BAD_REQUEST,
+      "IDは正の整数である必要があります。"
+    );
   });
 
   it("GET: 存在しないIDの場合404エラーを返す", async () => {
     const [request, context] = createGetRequest("100");
     const response = await GET(request, context);
 
-    await assertErrorResponse(response, 404, "指定されたブックマークがありません。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_NOT_FOUND,
+      "指定されたブックマークがありません。"
+    );
   });
 
   it("GET: データベースエラー時に500エラーを返す", async () => {
@@ -72,7 +86,11 @@ describe("ブックマークを1件取得するAPIのテスト", () => {
 
     const [request, context] = createGetRequest("1");
     const response = await GET(request, context);
-    await assertErrorResponse(response, 500, "サーバー内部でエラーが発生しました。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_INTERNAL_SERVER_ERROR,
+      "サーバー内部でエラーが発生しました。"
+    );
   });
 
   it("GET: クエリエラー時に500エラーを返す", async () => {
@@ -84,7 +102,11 @@ describe("ブックマークを1件取得するAPIのテスト", () => {
 
     const [request, context] = createGetRequest("1");
     const response = await GET(request, context);
-    await assertErrorResponse(response, 500, "サーバー内部でエラーが発生しました。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_INTERNAL_SERVER_ERROR,
+      "サーバー内部でエラーが発生しました。"
+    );
 
     prepareSpy.mockRestore();
   });

--- a/src/app/api/bookmarks/[bookmark_id]/keywords/post.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/keywords/post.test.ts
@@ -2,6 +2,12 @@ import ActualDatabase from "better-sqlite3"; // 実際のライブラリをイ�
 import { NextRequest } from "next/server";
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  HTTP_STATUS_BAD_REQUEST,
+  HTTP_STATUS_CONFLICT,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_NOT_FOUND,
+} from "../../../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../../../test-utils/assertions";
 import { setupInMemoryDb } from "../../../../test-utils/db-setup";
 import { isKeyword, KeywordPostParams } from "../../../../types/Keyword";
@@ -125,13 +131,21 @@ describe("POST /api/bookmarks/[bookmark_id]/keywords", () => {
     it("should return 404 if bookmark_id does not exist", async () => {
       const request = mockRequest({ keyword_name: "test-keyword" });
       const response = await POST(request, getPostParams("999"));
-      await assertErrorResponse(response, 404, "指定されたブックマークがありません。");
+      await assertErrorResponse(
+        response,
+        HTTP_STATUS_NOT_FOUND,
+        "指定されたブックマークがありません。"
+      );
     });
 
     it("should return 400 if bookmark_id is invalid", async () => {
       const request = mockRequest({ keyword_name: "test-keyword" });
       const response = await POST(request, getPostParams("invalid"));
-      await assertErrorResponse(response, 400, "IDは正の整数である必要があります。");
+      await assertErrorResponse(
+        response,
+        HTTP_STATUS_BAD_REQUEST,
+        "IDは正の整数である必要があります。"
+      );
     });
 
     it("should return 400 if request body is not valid JSON", async () => {
@@ -142,7 +156,11 @@ describe("POST /api/bookmarks/[bookmark_id]/keywords", () => {
       } as unknown as NextRequest;
 
       const response = await POST(request, getPostParams("1"));
-      await assertErrorResponse(response, 400, "リクエストボディのJSONが不正です。");
+      await assertErrorResponse(
+        response,
+        HTTP_STATUS_BAD_REQUEST,
+        "リクエストボディのJSONが不正です。"
+      );
     });
 
     it.each([
@@ -152,7 +170,11 @@ describe("POST /api/bookmarks/[bookmark_id]/keywords", () => {
     ])("should return 400 if keyword_name $case", async ({ body }) => {
       const request = mockRequest(body);
       const response = await POST(request, getPostParams("1"));
-      await assertErrorResponse(response, 400, "キーワードを指定してください。");
+      await assertErrorResponse(
+        response,
+        HTTP_STATUS_BAD_REQUEST,
+        "キーワードを指定してください。"
+      );
     });
 
     it("should return 409 if the keyword is already associated with the bookmark", async () => {
@@ -176,7 +198,7 @@ describe("POST /api/bookmarks/[bookmark_id]/keywords", () => {
       // Assert
       await assertErrorResponse(
         response,
-        409,
+        HTTP_STATUS_CONFLICT,
         "指定されたキーワードは既にこのブックマークに登録されています。"
       );
     });
@@ -190,7 +212,11 @@ describe("POST /api/bookmarks/[bookmark_id]/keywords", () => {
 
       const request = mockRequest({ keyword_name: "test-keyword" });
       const response = await POST(request, getPostParams("1"));
-      await assertErrorResponse(response, 500, "サーバー内部でエラーが発生しました。");
+      await assertErrorResponse(
+        response,
+        HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        "サーバー内部でエラーが発生しました。"
+      );
     });
   });
 });

--- a/src/app/api/bookmarks/[bookmark_id]/put.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/put.test.ts
@@ -1,6 +1,13 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  HTTP_STATUS_BAD_REQUEST,
+  HTTP_STATUS_CONFLICT,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_NO_CONTENT,
+  HTTP_STATUS_NOT_FOUND,
+} from "../../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../../test-utils/assertions";
 import { mockBookmarks } from "../../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../../test-utils/db-setup";
@@ -53,8 +60,8 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
     );
     const response = await PUT(request, context);
 
-    // レスポンスステータスを確認 (200 OK)
-    expect(response.status).toBe(204);
+    // レスポンスステータスを確認 (204 No Content)
+    expect(response.status).toBe(HTTP_STATUS_NO_CONTENT);
 
     // データベースが更新されたことを確認
     const selectStmt = inMemoryDbInstance.prepare(
@@ -94,8 +101,8 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
     );
     const response = await PUT(request, context);
 
-    // レスポンスステータスを確認 (200 OK)
-    expect(response.status).toBe(204);
+    // レスポンスステータスを確認 (204 No Content)
+    expect(response.status).toBe(HTTP_STATUS_NO_CONTENT);
 
     // データベースが更新されたことを確認
     const selectStmt = inMemoryDbInstance.prepare(
@@ -130,7 +137,11 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
     const response = await PUT(request, context);
 
     // レスポンスステータスを確認 (404 Not Found)
-    await assertErrorResponse(response, 404, "指定されたブックマークがありません。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_NOT_FOUND,
+      "指定されたブックマークがありません。"
+    );
   });
 
   it("PUT: タイトルが指定されていない場合には400を返す。", async () => {
@@ -150,7 +161,7 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
     const response = await PUT(request, context);
 
     // レスポンスステータスを確認 (400: Bad Request)
-    await assertErrorResponse(response, 400, "タイトルを指定してください。");
+    await assertErrorResponse(response, HTTP_STATUS_BAD_REQUEST, "タイトルを指定してください。");
   });
 
   it("PUT: URLが指定されていない場合には400を返す。", async () => {
@@ -170,7 +181,7 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
     const response = await PUT(request, context);
 
     // レスポンスステータスを確認 (400: Bad Request)
-    await assertErrorResponse(response, 400, "URLを指定してください。");
+    await assertErrorResponse(response, HTTP_STATUS_BAD_REQUEST, "URLを指定してください。");
   });
 
   it("PUT: IDが指定されていない場合には400を返す。", async () => {
@@ -191,7 +202,11 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
     });
 
     // レスポンスステータスを確認 (400: Bad Request)
-    await assertErrorResponse(response, 400, "IDは正の整数である必要があります。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_BAD_REQUEST,
+      "IDは正の整数である必要があります。"
+    );
   });
 
   it("PUT: 不正な形式(文字列)のIDが指定された場合には400を返す。", async () => {
@@ -213,7 +228,11 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
     });
 
     // レスポンスステータスを確認 (400: Bad Request)
-    await assertErrorResponse(response, 400, "IDは正の整数である必要があります。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_BAD_REQUEST,
+      "IDは正の整数である必要があります。"
+    );
   });
 
   it("PUT: 不正なJSONデータの場合は400を返す。", async () => {
@@ -226,7 +245,11 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
     const [request, context] = createPutRequest("invalid json data", bookmarkToUpdate.bookmark_id);
     const response = await PUT(request, context);
 
-    await assertErrorResponse(response, 400, "リクエストボディのJSONが不正です。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_BAD_REQUEST,
+      "リクエストボディのJSONが不正です。"
+    );
   });
 
   it("PUT: クエリエラー時に500エラーを返す", async () => {
@@ -251,7 +274,11 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
     );
     const response = await PUT(request, context);
 
-    await assertErrorResponse(response, 500, "サーバー内部でエラーが発生しました。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_INTERNAL_SERVER_ERROR,
+      "サーバー内部でエラーが発生しました。"
+    );
 
     prepareSpy.mockRestore();
   });
@@ -273,6 +300,10 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
     const response = await PUT(request, context);
 
     // レスポンスステータスを確認 (409: Conflict
-    await assertErrorResponse(response, 409, "指定されたURLのブックマークは既に登録されています。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_CONFLICT,
+      "指定されたURLのブックマークは既に登録されています。"
+    );
   });
 });

--- a/src/app/api/bookmarks/[bookmark_id]/route.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/route.ts
@@ -2,9 +2,10 @@
 
 import { SqliteError } from "better-sqlite3";
 
-import { Bookmark, parseAndValidateKeywords } from "../../../types/Bookmark";
 import { BookmarkFromDb } from "@/app/types/database";
 
+import { HTTP_STATUS_NO_CONTENT, HTTP_STATUS_OK } from "../../../constants/httpStatusCodes";
+import { Bookmark, parseAndValidateKeywords } from "../../../types/Bookmark";
 import { getBookmarkIdAsync, InvalidIdError } from "../../utils/id";
 import {
   createDuplicateBookmarkError,
@@ -54,7 +55,7 @@ export async function GET(
       keywords: parseAndValidateKeywords(bookmarkFromDb.keywords),
     };
     return new Response(JSON.stringify(bookmark), {
-      status: 200,
+      status: HTTP_STATUS_OK,
       headers: { "Content-Type": "application/json" },
     });
   } catch (error: unknown) {
@@ -87,7 +88,7 @@ export async function PUT(
     if (info.changes === 0) {
       return createNotFoundBookmarkError(bookmark_id);
     }
-    return new Response(null, { status: 204 });
+    return new Response(null, { status: HTTP_STATUS_NO_CONTENT });
   } catch (error: unknown) {
     if (error instanceof SyntaxError) {
       return createInvalidBodyError(error);
@@ -115,7 +116,7 @@ export async function DELETE(
     if (info.changes === 0) {
       return createNotFoundBookmarkError(bookmark_id);
     }
-    return new Response(null, { status: 204 });
+    return new Response(null, { status: HTTP_STATUS_NO_CONTENT });
   } catch (error: unknown) {
     if (error instanceof InvalidIdError) {
       return createInvalidIdError({ id: (await params).bookmark_id });

--- a/src/app/api/bookmarks/get.test.ts
+++ b/src/app/api/bookmarks/get.test.ts
@@ -1,8 +1,9 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { expectEqualBookmark, mockBookmarks } from "../../test-utils/bookmarkTestUtils";
+import { HTTP_STATUS_INTERNAL_SERVER_ERROR, HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../test-utils/assertions";
+import { expectEqualBookmark, mockBookmarks } from "../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../test-utils/db-setup";
 import { getDb } from "./database";
 import { GET } from "./route";
@@ -30,7 +31,7 @@ describe("ブックマークのAPIのテスト", () => {
   it("GET: ブックマークのデータが取得できる", async () => {
     const response = await GET();
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(HTTP_STATUS_OK);
     const json = await response.json();
 
     expect(json).toHaveLength(mockBookmarks.length);
@@ -47,7 +48,11 @@ describe("ブックマークのAPIのテスト", () => {
     });
 
     const response = await GET();
-    await assertErrorResponse(response, 500, "サーバー内部でエラーが発生しました。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_INTERNAL_SERVER_ERROR,
+      "サーバー内部でエラーが発生しました。"
+    );
   });
 
   it("GET: クエリエラー時に500エラーを返す", async () => {
@@ -58,7 +63,11 @@ describe("ブックマークのAPIのテスト", () => {
     });
 
     const response = await GET();
-    await assertErrorResponse(response, 500, "サーバー内部でエラーが発生しました。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_INTERNAL_SERVER_ERROR,
+      "サーバー内部でエラーが発生しました。"
+    );
 
     prepareSpy.mockRestore();
   });

--- a/src/app/api/bookmarks/post.test.ts
+++ b/src/app/api/bookmarks/post.test.ts
@@ -1,8 +1,14 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createBookmark, mockBookmarks } from "../../test-utils/bookmarkTestUtils";
+import {
+  HTTP_STATUS_BAD_REQUEST,
+  HTTP_STATUS_CONFLICT,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_NO_CONTENT,
+} from "../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../test-utils/assertions";
+import { createBookmark, mockBookmarks } from "../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../test-utils/db-setup";
 import { Bookmark } from "../../types/Bookmark";
 import { API_BOOKMARKS_URL } from "../utils/constants";
@@ -90,7 +96,11 @@ describe("ブックマーク追加APIのテスト (オンメモリDB)", () => {
   it("POST: 不正なJSONデータの場合はエラーを返す", async () => {
     const response = await POST(createPostRequest("invalid json"));
 
-    await assertErrorResponse(response, 400, "リクエストボディのJSONが不正です。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_BAD_REQUEST,
+      "リクエストボディのJSONが不正です。"
+    );
   });
 
   it("POST: クエリエラー時に500エラーを返す", async () => {
@@ -106,7 +116,11 @@ describe("ブックマーク追加APIのテスト (オンメモリDB)", () => {
     });
 
     const response = await POST(createPostRequest(JSON.stringify(bookmark)));
-    await assertErrorResponse(response, 500, "サーバー内部でエラーが発生しました。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_INTERNAL_SERVER_ERROR,
+      "サーバー内部でエラーが発生しました。"
+    );
 
     prepareSpy.mockRestore();
   });
@@ -119,7 +133,11 @@ describe("ブックマーク追加APIのテスト (オンメモリDB)", () => {
 
     const response = await POST(createPostRequest(JSON.stringify(bookmark)));
 
-    await assertErrorResponse(response, 409, "指定されたURLのブックマークは既に登録されています。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_CONFLICT,
+      "指定されたURLのブックマークは既に登録されています。"
+    );
   });
 
   it("POST: URLが空文字の場合にエラーを返す", async () => {
@@ -129,7 +147,7 @@ describe("ブックマーク追加APIのテスト (オンメモリDB)", () => {
 
     const response = await POST(createPostRequest(JSON.stringify(bookmark)));
 
-    await assertErrorResponse(response, 400, "URLを指定してください。");
+    await assertErrorResponse(response, HTTP_STATUS_BAD_REQUEST, "URLを指定してください。");
   });
 
   it("POST: タイトルが空文字の場合にエラーを返す", async () => {
@@ -139,14 +157,14 @@ describe("ブックマーク追加APIのテスト (オンメモリDB)", () => {
 
     const response = await POST(createPostRequest(JSON.stringify(bookmark)));
 
-    await assertErrorResponse(response, 400, "タイトルを指定してください。");
+    await assertErrorResponse(response, HTTP_STATUS_BAD_REQUEST, "タイトルを指定してください。");
   });
 
   // --- OPTIONS Tests ---
   it("OPTIONS: 適切なCORSヘッダーを返す", async () => {
     const response = await OPTIONS(); // OPTIONS handler might not take a request argument
 
-    expect(response.status).toBe(204);
+    expect(response.status).toBe(HTTP_STATUS_NO_CONTENT);
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
       "chrome-extension://jonckoigjppkhajocdbgfbgjdgffhebf"
     );

--- a/src/app/api/bookmarks/route.ts
+++ b/src/app/api/bookmarks/route.ts
@@ -1,11 +1,12 @@
 "use server";
 import { SqliteError } from "better-sqlite3";
 
-import { Bookmark, IncomingBookmarkPayload, parseAndValidateKeywords } from "../../types/Bookmark";
 import { BookmarkFromDb } from "@/app/types/database";
 
 import eventEmitter from "../../../lib/event-emitter";
 import { ALLOWED_CORS_ORIGIN } from "../../constants/apiEndpoints";
+import { HTTP_STATUS_NO_CONTENT, HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
+import { Bookmark, IncomingBookmarkPayload, parseAndValidateKeywords } from "../../types/Bookmark";
 import { API_BOOKMARKS_URL } from "../utils/constants";
 import {
   createDuplicateBookmarkError,
@@ -48,7 +49,7 @@ export async function GET() {
       })
     );
     return new Response(JSON.stringify(bookmarks), {
-      status: 200,
+      status: HTTP_STATUS_OK,
       headers: { "Content-Type": "application/json" },
     });
   } catch (error: unknown) {
@@ -58,7 +59,7 @@ export async function GET() {
 
 export const OPTIONS = async () => {
   return new Response(null, {
-    status: 204, // No Content
+    status: HTTP_STATUS_NO_CONTENT, // No Content
     headers: {
       "Access-Control-Allow-Origin": ALLOWED_CORS_ORIGIN,
       "Access-Control-Allow-Methods": "POST, OPTIONS",

--- a/src/app/api/events/route.test.ts
+++ b/src/app/api/events/route.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { HTTP_STATUS_OK } from "../../../app/constants/httpStatusCodes";
 import eventEmitter from "../../../lib/event-emitter";
-
 import { dynamic, GET } from "./route";
 
 // Mock the event emitter to control its behavior in tests
@@ -27,7 +27,7 @@ describe("SSE /api/events", () => {
     const request = new Request("http://localhost/api/events");
     const response = await GET(request);
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(HTTP_STATUS_OK);
     expect(response.headers.get("Content-Type")).toBe("text/event-stream");
     expect(response.headers.get("Cache-Control")).toBe("no-cache");
     expect(response.headers.get("Connection")).toBe("keep-alive");
@@ -74,10 +74,7 @@ describe("SSE /api/events", () => {
 
     abortController.abort();
 
-    expect(vi.mocked(eventEmitter.off)).toHaveBeenCalledWith(
-      "bookmarks-updated",
-      onUpdateHandler
-    );
+    expect(vi.mocked(eventEmitter.off)).toHaveBeenCalledWith("bookmarks-updated", onUpdateHandler);
 
     const reader = response.body!.getReader();
     const result = await reader.read();

--- a/src/app/api/keywords/[keyword_id]/delete.test.ts
+++ b/src/app/api/keywords/[keyword_id]/delete.test.ts
@@ -1,6 +1,12 @@
 import ActualDatabase from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  HTTP_STATUS_BAD_REQUEST,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_NO_CONTENT,
+  HTTP_STATUS_NOT_FOUND,
+} from "../../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../../test-utils/assertions";
 import { setupInMemoryDb } from "../../../test-utils/db-setup";
 import { getDb } from "../../bookmarks/database";
@@ -36,22 +42,34 @@ describe("キーワードDELETE APIのテスト", () => {
   it("DELETE: 正常にキーワードが削除できる", async () => {
     const [req, ctx] = createDeleteRequest("1");
     const response = await DELETE(req, ctx);
-    expect(response.status).toBe(204);
+    expect(response.status).toBe(HTTP_STATUS_NO_CONTENT);
     // 削除後にもう一度削除を試みると404になることを確認
     const response2 = await DELETE(req, ctx);
-    await assertErrorResponse(response2, 404, "指定されたキーワードが見つかりません。");
+    await assertErrorResponse(
+      response2,
+      HTTP_STATUS_NOT_FOUND,
+      "指定されたキーワードが見つかりません。"
+    );
   });
 
   it("DELETE: 存在しないIDの場合404を返す", async () => {
     const [req, ctx] = createDeleteRequest("9999");
     const response = await DELETE(req, ctx);
-    await assertErrorResponse(response, 404, "指定されたキーワードが見つかりません。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_NOT_FOUND,
+      "指定されたキーワードが見つかりません。"
+    );
   });
 
   it("DELETE: 不正なIDの場合400を返す", async () => {
     const [req, ctx] = createDeleteRequest("abc");
     const response = await DELETE(req, ctx);
-    await assertErrorResponse(response, 400, "IDは正の整数である必要があります。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_BAD_REQUEST,
+      "IDは正の整数である必要があります。"
+    );
   });
 
   it("DELETE: DBエラー時は500を返す", async () => {
@@ -60,6 +78,10 @@ describe("キーワードDELETE APIのテスト", () => {
     });
     const [req, ctx] = createDeleteRequest("1");
     const response = await DELETE(req, ctx);
-    await assertErrorResponse(response, 500, "サーバー内部でエラーが発生しました。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_INTERNAL_SERVER_ERROR,
+      "サーバー内部でエラーが発生しました。"
+    );
   });
 });

--- a/src/app/api/keywords/[keyword_id]/route.ts
+++ b/src/app/api/keywords/[keyword_id]/route.ts
@@ -7,6 +7,7 @@ import {
   createInvalidIdError,
   createNotFoundKeywordError,
 } from "../../utils/response";
+import { HTTP_STATUS_NO_CONTENT } from "../../../constants/httpStatusCodes";
 
 export const DELETE = async (
   _request: Request,
@@ -20,7 +21,7 @@ export const DELETE = async (
     if (result.changes === 0) {
       return createNotFoundKeywordError(keyword_id);
     }
-    return new Response(null, { status: 204 });
+    return new Response(null, { status: HTTP_STATUS_NO_CONTENT });
   } catch (error: unknown) {
     if (error instanceof InvalidIdError) {
       return createInvalidIdError({ id: (await params).keyword_id });

--- a/src/app/api/keywords/get.test.ts
+++ b/src/app/api/keywords/get.test.ts
@@ -1,6 +1,7 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { HTTP_STATUS_INTERNAL_SERVER_ERROR, HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../test-utils/assertions";
 import { mockKeywords } from "../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../test-utils/db-setup";
@@ -30,7 +31,7 @@ describe("キーワードGET APIのテスト", () => {
   it("GET: キーワードのデータが取得できる", async () => {
     const response = await GET();
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(HTTP_STATUS_OK);
     const json = await response.json();
     expect(json).toEqual(mockKeywords);
   });
@@ -42,7 +43,11 @@ describe("キーワードGET APIのテスト", () => {
     });
 
     const response = await GET();
-    await assertErrorResponse(response, 500, "サーバー内部でエラーが発生しました。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_INTERNAL_SERVER_ERROR,
+      "サーバー内部でエラーが発生しました。"
+    );
   });
 
   it("GET: クエリエラー時に500エラーを返す", async () => {
@@ -53,7 +58,11 @@ describe("キーワードGET APIのテスト", () => {
     });
 
     const response = await GET();
-    await assertErrorResponse(response, 500, "サーバー内部でエラーが発生しました。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_INTERNAL_SERVER_ERROR,
+      "サーバー内部でエラーが発生しました。"
+    );
 
     prepareSpy.mockRestore();
   });

--- a/src/app/api/keywords/post.test.ts
+++ b/src/app/api/keywords/post.test.ts
@@ -1,6 +1,11 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  HTTP_STATUS_BAD_REQUEST,
+  HTTP_STATUS_CONFLICT,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+} from "../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../test-utils/assertions";
 import { mockKeywords } from "../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../test-utils/db-setup";
@@ -65,7 +70,7 @@ describe("キーワードAPIのテスト", () => {
   it("POST: キーワードが空文字の場合は400を返す", async () => {
     const response = await POST(createPostRequest(""));
 
-    await assertErrorResponse(response, 400, "キーワードを指定してください。");
+    await assertErrorResponse(response, HTTP_STATUS_BAD_REQUEST, "キーワードを指定してください。");
   });
 
   it("POST: 不正なJSONデータ(JSON.parseエラー)の場合は400を返す", async () => {
@@ -78,7 +83,11 @@ describe("キーワードAPIのテスト", () => {
         body: "invalid json",
       })
     );
-    await assertErrorResponse(response, 400, "リクエストボディのJSONが不正です。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_BAD_REQUEST,
+      "リクエストボディのJSONが不正です。"
+    );
   });
 
   it("POST: 不正なJSONデータ(null)の場合は400を返す", async () => {
@@ -91,13 +100,21 @@ describe("キーワードAPIのテスト", () => {
         body: JSON.stringify(null),
       })
     );
-    await assertErrorResponse(response, 400, "リクエストボディのJSONが不正です。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_BAD_REQUEST,
+      "リクエストボディのJSONが不正です。"
+    );
   });
 
   it("POST: 重複したキーワードを追加時に409 Conflictを返す", async () => {
     const response = await POST(createPostRequest(mockKeywords[0].keyword_name));
 
-    await assertErrorResponse(response, 409, "指定されたキーワードは既に登録されています。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_CONFLICT,
+      "指定されたキーワードは既に登録されています。"
+    );
   });
 
   it("POST: データベースエラー時に500エラーを返す", async () => {
@@ -108,7 +125,11 @@ describe("キーワードAPIのテスト", () => {
     });
 
     const response = await POST(createPostRequest("テスト"));
-    await assertErrorResponse(response, 500, "サーバー内部でエラーが発生しました。");
+    await assertErrorResponse(
+      response,
+      HTTP_STATUS_INTERNAL_SERVER_ERROR,
+      "サーバー内部でエラーが発生しました。"
+    );
 
     prepareSpy.mockRestore();
   });

--- a/src/app/api/keywords/route.ts
+++ b/src/app/api/keywords/route.ts
@@ -1,6 +1,7 @@
 "use server";
 import { SqliteError } from "better-sqlite3";
 
+import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import { getDb } from "../bookmarks/database";
 import {
   createDuplicateKeywordError,
@@ -15,7 +16,7 @@ export const GET = async () => {
     const stmt = db.prepare("SELECT keyword_id, keyword_name FROM keywords");
     const keywords = stmt.all();
     return new Response(JSON.stringify(keywords), {
-      status: 200,
+      status: HTTP_STATUS_OK,
       headers: { "Content-Type": "application/json" },
     });
   } catch (error: unknown) {
@@ -56,9 +57,7 @@ export const POST = async (request: Request): Promise<Response> => {
 
     // データベース操作
     const db = getDb();
-    const insertStmt = db.prepare(
-      "INSERT INTO keywords (keyword_name) VALUES (?)"
-    );
+    const insertStmt = db.prepare("INSERT INTO keywords (keyword_name) VALUES (?)");
     const result = insertStmt.run(keyword.keyword_name);
 
     // キーワードの追加に成功
@@ -73,10 +72,7 @@ export const POST = async (request: Request): Promise<Response> => {
       }
     );
   } catch (error: unknown) {
-    if (
-      error instanceof SqliteError &&
-      error.code === "SQLITE_CONSTRAINT_UNIQUE"
-    ) {
+    if (error instanceof SqliteError && error.code === "SQLITE_CONSTRAINT_UNIQUE") {
       return createDuplicateKeywordError(keywordName);
     }
     return createInternalError(error);

--- a/src/app/api/utils/ApiUtils.ts
+++ b/src/app/api/utils/ApiUtils.ts
@@ -1,5 +1,7 @@
 import type { ApiErrorResponse } from "@/app/types/ApiResponse";
 
+import { HTTP_STATUS_CONFLICT } from "../../constants/httpStatusCodes";
+
 /**
  * APIエラーを表すカスタムエラークラス。
  * @param message - エラーメッセージ（フォーマット前）
@@ -35,7 +37,7 @@ export class ApiError extends Error {
 
 export class DuplicatedUrlError extends ApiError {
   constructor(message: string, options?: { cause: unknown }) {
-    super(message, 409, options);
+    super(message, HTTP_STATUS_CONFLICT, options);
     this.name = "DuplicatedUrlError";
   }
 }
@@ -123,7 +125,7 @@ export const parseApiError = async (response: Response): Promise<ApiError> => {
       cause = createErrorCauseFromContext({ error: e, body: bodyText });
     }
   }
-  if (response.status === 409) {
+  if (response.status === HTTP_STATUS_CONFLICT) {
     return new DuplicatedUrlError(message, { cause });
   }
   return new ApiError(message, response.status, { cause });

--- a/src/app/api/utils/response.ts
+++ b/src/app/api/utils/response.ts
@@ -1,3 +1,10 @@
+import {
+  HTTP_STATUS_BAD_REQUEST,
+  HTTP_STATUS_CONFLICT,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_NOT_FOUND,
+} from "../../constants/httpStatusCodes";
+
 const ensureError = (error: unknown): Error =>
   error instanceof Error ? error : new Error(String(error));
 
@@ -23,7 +30,7 @@ export const createErrorResponse = (
 export function createInvalidIdError(params: { id: string }) {
   return createErrorResponse(
     "IDは正の整数である必要があります。",
-    400,
+    HTTP_STATUS_BAD_REQUEST,
     `Invalid ID provided: ${params.id}. It must be a positive integer.`
   );
 }
@@ -31,7 +38,7 @@ export function createInvalidIdError(params: { id: string }) {
 export const createInternalError = (error: unknown, headers: Record<string, string> = {}) => {
   return createErrorResponse(
     "サーバー内部でエラーが発生しました。",
-    500,
+    HTTP_STATUS_INTERNAL_SERVER_ERROR,
     `Internal Server Error: ${ensureError(error).message}`,
     headers
   );
@@ -40,19 +47,24 @@ export const createInternalError = (error: unknown, headers: Record<string, stri
 export const createNotFoundKeywordError = (keyword_id: number) => {
   return createErrorResponse(
     "指定されたキーワードが見つかりません。",
-    404,
+    HTTP_STATUS_NOT_FOUND,
     `Keyword with id: ${keyword_id} not found.`
   );
 };
 
 export const createNoUrlError = (headers: Record<string, string> = {}) => {
-  return createErrorResponse("URLを指定してください。", 400, "URLが指定されていません。", headers);
+  return createErrorResponse(
+    "URLを指定してください。",
+    HTTP_STATUS_BAD_REQUEST,
+    "URLが指定されていません。",
+    headers
+  );
 };
 
 export const createNoTitleError = (headers: Record<string, string> = {}) => {
   return createErrorResponse(
     "タイトルを指定してください。",
-    400,
+    HTTP_STATUS_BAD_REQUEST,
     "タイトルが指定されていません。",
     headers
   );
@@ -61,7 +73,7 @@ export const createNoTitleError = (headers: Record<string, string> = {}) => {
 export const createDuplicateBookmarkError = (url: string, headers: Record<string, string> = {}) => {
   return createErrorResponse(
     "指定されたURLのブックマークは既に登録されています。",
-    409,
+    HTTP_STATUS_CONFLICT,
     `Bookmark with URL \"${url}\" already exists.`,
     headers
   );
@@ -73,7 +85,7 @@ export const createDuplicateKeywordError = (
 ) => {
   return createErrorResponse(
     "指定されたキーワードは既に登録されています。",
-    409,
+    HTTP_STATUS_CONFLICT,
     `Keyword with \"${keyword}\" already exists.`,
     headers
   );
@@ -82,7 +94,7 @@ export const createDuplicateKeywordError = (
 export const createInvalidBodyError = (error: unknown, headers: Record<string, string> = {}) => {
   return createErrorResponse(
     "リクエストボディのJSONが不正です。",
-    400,
+    HTTP_STATUS_BAD_REQUEST,
     `Invalid JSON format: ${ensureError(error).message}`,
     headers
   );
@@ -91,7 +103,7 @@ export const createInvalidBodyError = (error: unknown, headers: Record<string, s
 export const createNotFoundBookmarkError = (bookmark_id: number) => {
   return createErrorResponse(
     "指定されたブックマークがありません。",
-    404,
+    HTTP_STATUS_NOT_FOUND,
     `Bookmark with id: ${bookmark_id} not found.`
   );
 };
@@ -99,7 +111,7 @@ export const createNotFoundBookmarkError = (bookmark_id: number) => {
 export const createNoKeywordError = () => {
   return createErrorResponse(
     "キーワードを指定してください。",
-    400,
+    HTTP_STATUS_BAD_REQUEST,
     "キーワードが指定されていません。"
   );
 };
@@ -107,7 +119,7 @@ export const createNoKeywordError = () => {
 export const createDuplicateKeywordAssociationError = (bookmarkId: number, keywordName: string) => {
   return createErrorResponse(
     "指定されたキーワードは既にこのブックマークに登録されています。",
-    409,
+    HTTP_STATUS_CONFLICT,
     `Keyword "${keywordName}" is already associated with bookmark id: ${bookmarkId}.`
   );
 };

--- a/src/app/components/BookmarkManager/delete.test.tsx
+++ b/src/app/components/BookmarkManager/delete.test.tsx
@@ -8,6 +8,13 @@ import userEvent, { UserEvent } from "@testing-library/user-event";
 import { BOOKMARKS_ENDPOINT } from "../../constants/apiEndpoints";
 import { DELETE_BUTTON_ROLE_NAME } from "../../constants/constants";
 import {
+  HTTP_STATUS_BAD_REQUEST,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_NO_CONTENT,
+  HTTP_STATUS_NOT_FOUND,
+  HTTP_STATUS_OK,
+} from "../../constants/httpStatusCodes";
+import {
   assertBookmarkIsSelected,
   clickBookmark,
   createMockResponse,
@@ -34,7 +41,7 @@ describe("削除ボタン", () => {
     mockFetch.mockReset();
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      status: 200,
+      status: HTTP_STATUS_OK,
       json: async () => mockBookmarks,
     });
 
@@ -64,7 +71,9 @@ describe("削除ボタン", () => {
     });
 
     it("ブックマークが削除される(APIの呼び出し、画面の更新)", async () => {
-      mockFetch.mockResolvedValueOnce(createMockResponse({ isOk: true, status: 204 }));
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({ isOk: true, status: HTTP_STATUS_NO_CONTENT })
+      );
 
       await clickDeleteButton(user);
 
@@ -89,15 +98,24 @@ describe("削除ボタン", () => {
     it.each([
       {
         description: "存在しないブックマーク (404 Not Found)",
-        errorCase: { message: "指定されたブックマークがありません。", status: 404 },
+        errorCase: {
+          message: "指定されたブックマークがありません。",
+          status: HTTP_STATUS_NOT_FOUND,
+        },
       },
       {
         description: "不正なリクエスト (400 Bad Request)",
-        errorCase: { message: "リクエストにIDがありませんでした。", status: 400 },
+        errorCase: {
+          message: "リクエストにIDがありませんでした。",
+          status: HTTP_STATUS_BAD_REQUEST,
+        },
       },
       {
         description: "サーバーエラー (500 Internal Server Error)",
-        errorCase: { message: "サーバーで予期せぬエラーが発生しました。", status: 500 },
+        errorCase: {
+          message: "サーバーで予期せぬエラーが発生しました。",
+          status: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        },
       },
     ])("エラーハンドリング: $description", async ({ errorCase }) => {
       const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/app/components/BookmarkManager/hotkeys.test.tsx
+++ b/src/app/components/BookmarkManager/hotkeys.test.tsx
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 import { screen, waitFor } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 
+import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   assertNoBookmarkIsSelected,
@@ -66,7 +67,7 @@ describe("BookmarkManager Hotkeys", () => {
     global.fetch = mockFetch;
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      status: 200,
+      status: HTTP_STATUS_OK,
       json: async () => mockBookmarks,
     });
 

--- a/src/app/components/BookmarkManager/keyword.add.test.tsx
+++ b/src/app/components/BookmarkManager/keyword.add.test.tsx
@@ -11,6 +11,7 @@ import {
   KEYWORD_ROLE_NAME,
   TABLE_NAME_KEYWORD,
 } from "../../constants/constants";
+import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   buildMockBookmarksWithKeywords,
@@ -66,7 +67,7 @@ describe("選択されたブックマークにキーワードを追加", () => {
     mockBookmarksWithKeywords = buildMockBookmarksWithKeywords();
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      status: 200,
+      status: HTTP_STATUS_OK,
       json: async () => mockBookmarksWithKeywords,
     });
     user = userEvent.setup();

--- a/src/app/components/BookmarkManager/keyword.view.test.tsx
+++ b/src/app/components/BookmarkManager/keyword.view.test.tsx
@@ -11,6 +11,7 @@ import {
   KEYWORD_ROLE_NAME,
   TABLE_NAME_KEYWORD,
 } from "../../constants/constants";
+import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   buildMockBookmarksWithKeywords,
@@ -35,7 +36,7 @@ describe("キーワード詳細フォームの表示のテスト", () => {
     global.fetch = mockFetch;
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      status: 200,
+      status: HTTP_STATUS_OK,
       json: async () => mockBookmarksWithKeywords,
     });
     user = userEvent.setup();

--- a/src/app/components/BookmarkManager/open.test.tsx
+++ b/src/app/components/BookmarkManager/open.test.tsx
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 import { screen, waitFor } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 
+import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   clickBookmark,
@@ -67,7 +68,7 @@ describe("「開く」ボタン: 入力されたURLを新しいタブで開く",
     global.fetch = mockFetch;
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      status: 200,
+      status: HTTP_STATUS_OK,
       json: async () => mockBookmarks,
     });
 

--- a/src/app/components/BookmarkManager/parameter.test.tsx
+++ b/src/app/components/BookmarkManager/parameter.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, it, vi } from "vitest";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 
 import { PARAMETER_BUTTON_ROLE_NAME } from "../../constants/constants";
+import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   clickBookmark,
@@ -25,7 +26,7 @@ describe("「パラメータ」ボタン: URLから無駄な文字列を削除�
       global.fetch = mockFetch;
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        status: 200,
+        status: HTTP_STATUS_OK,
         json: async () => mockBookmarks,
       });
 

--- a/src/app/components/BookmarkManager/path.test.tsx
+++ b/src/app/components/BookmarkManager/path.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, it, vi } from "vitest";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 
 import { ARROW_BUTTON_ROLE_NAME } from "../../constants/constants";
+import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   clickBookmark,
@@ -24,7 +25,7 @@ describe("「←」ボタン", () => {
     global.fetch = mockFetch;
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      status: 200,
+      status: HTTP_STATUS_OK,
       json: async () => mockBookmarks,
     });
 

--- a/src/app/components/BookmarkManager/select.test.tsx
+++ b/src/app/components/BookmarkManager/select.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import userEvent, { UserEvent } from "@testing-library/user-event";
 
+import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   assertNoBookmarkIsSelected,
@@ -25,7 +26,7 @@ describe("ブックマークの選択", () => {
     global.fetch = mockFetch;
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      status: 200,
+      status: HTTP_STATUS_OK,
       json: async () => mockBookmarks,
     });
     user = userEvent.setup();

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -8,6 +8,14 @@ import userEvent, { UserEvent } from "@testing-library/user-event";
 import { BOOKMARKS_ENDPOINT } from "../../constants/apiEndpoints";
 import { TABLE_NAME_BOOKMARKS, UPDATE_BUTTON_ROLE_NAME } from "../../constants/constants";
 import {
+  HTTP_STATUS_BAD_REQUEST,
+  HTTP_STATUS_CONFLICT,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_NO_CONTENT,
+  HTTP_STATUS_NOT_FOUND,
+  HTTP_STATUS_OK,
+} from "../../constants/httpStatusCodes";
+import {
   assertBookmarkIsSelected,
   clickBookmark,
   createBookmark,
@@ -37,7 +45,7 @@ describe("タイトルの更新ボタン", () => {
     global.fetch = mockFetch;
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      status: 200,
+      status: HTTP_STATUS_OK,
       json: async () => mockBookmarks,
     });
     user = userEvent.setup();
@@ -70,7 +78,7 @@ describe("タイトルの更新ボタン", () => {
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
           isOk: true,
-          status: 204,
+          status: HTTP_STATUS_NO_CONTENT,
         })
       );
 
@@ -128,7 +136,7 @@ describe("タイトルの更新ボタン", () => {
         const updateUrl = mockBookmarks[2].url;
         const updateTitle = "更新されたタイトル";
         const errorText = "指定されたURLのブックマークは既に登録されています。";
-        const statusCode = 409;
+        const statusCode = HTTP_STATUS_CONFLICT;
 
         mockFetch.mockResolvedValueOnce(
           createMockResponse({
@@ -165,22 +173,31 @@ describe("タイトルの更新ボタン", () => {
       it.each([
         {
           description: "存在しないブックマーク (404 Not Found)",
-          errorCase: { message: "指定されたブックマークがありません。", status: 404 },
+          errorCase: {
+            message: "指定されたブックマークがありません。",
+            status: HTTP_STATUS_NOT_FOUND,
+          },
         },
         {
           description: "不正なリクエスト (400 Bad Request)",
-          errorCase: { message: "リクエストにIDがありませんでした。", status: 400 },
+          errorCase: {
+            message: "リクエストにIDがありませんでした。",
+            status: HTTP_STATUS_BAD_REQUEST,
+          },
         },
         {
           description: "IDの形式が不正 (400 Bad Request)",
           errorCase: {
             message: "IDは正の整数である必要があります。",
-            status: 400,
+            status: HTTP_STATUS_BAD_REQUEST,
           },
         },
         {
           description: "不正なJSONデータ (500 Internal Server Error)",
-          errorCase: { message: "サーバーで予期せぬエラーが発生しました。", status: 500 },
+          errorCase: {
+            message: "サーバーで予期せぬエラーが発生しました。",
+            status: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+          },
         },
       ])("エラーハンドリング: $description", async ({ errorCase }) => {
         mockFetch.mockResolvedValueOnce(createMockResponse({ ...errorCase, isOk: false }));

--- a/src/app/components/BookmarkManager/view.test.tsx
+++ b/src/app/components/BookmarkManager/view.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { render, screen } from "@testing-library/react";
 
+import { HTTP_STATUS_INTERNAL_SERVER_ERROR, HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import { mockBookmarks } from "../../test-utils/bookmarkTestUtils";
 import { BookmarkManager } from "../BookmarkManager";
 
@@ -18,7 +19,7 @@ describe("BookmarkManagerの表示を確認", () => {
   it("すべてのエレメントが表示されることを確認", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      status: 200,
+      status: HTTP_STATUS_OK,
       json: async () => mockBookmarks,
     });
 
@@ -31,7 +32,7 @@ describe("BookmarkManagerの表示を確認", () => {
   it("ローディング中にローディングメッセージが表示されること", () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      status: 200,
+      status: HTTP_STATUS_OK,
       json: async () => new Promise(() => []),
     });
 
@@ -43,7 +44,7 @@ describe("BookmarkManagerの表示を確認", () => {
   it("HTTPステータス500でfetchした場合、エラーメッセージが表示される", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const errorText = "Internal Error";
-    const statusCode = 500;
+    const statusCode = HTTP_STATUS_INTERNAL_SERVER_ERROR;
 
     mockFetch.mockResolvedValueOnce({
       ok: false,

--- a/src/app/constants/httpStatusCodes.ts
+++ b/src/app/constants/httpStatusCodes.ts
@@ -1,5 +1,7 @@
 export const HTTP_STATUS_OK = 200;
+export const HTTP_STATUS_CREATED = 201;
 export const HTTP_STATUS_NO_CONTENT = 204;
+export const HTTP_STATUS_MULTIPLE_CHOICES = 300;
 export const HTTP_STATUS_BAD_REQUEST = 400;
 export const HTTP_STATUS_NOT_FOUND = 404;
 export const HTTP_STATUS_CONFLICT = 409;

--- a/src/app/constants/httpStatusCodes.ts
+++ b/src/app/constants/httpStatusCodes.ts
@@ -1,0 +1,6 @@
+export const HTTP_STATUS_OK = 200;
+export const HTTP_STATUS_NO_CONTENT = 204;
+export const HTTP_STATUS_BAD_REQUEST = 400;
+export const HTTP_STATUS_NOT_FOUND = 404;
+export const HTTP_STATUS_CONFLICT = 409;
+export const HTTP_STATUS_INTERNAL_SERVER_ERROR = 500;

--- a/src/app/hooks/useBookmarkManager.test.tsx
+++ b/src/app/hooks/useBookmarkManager.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 
+import { HTTP_STATUS_OK } from "../constants/httpStatusCodes";
 import { mockBookmarks } from "../test-utils/bookmarkTestUtils";
 import { useBookmarkManager } from "./useBookmarkManager";
 
@@ -13,7 +14,7 @@ describe("useBookmarkManager", () => {
     global.fetch = mockFetch;
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      status: 200,
+      status: HTTP_STATUS_OK,
       json: async () => mockBookmarks,
     });
   });

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -7,6 +7,8 @@ import { render, screen } from "@testing-library/react";
 import Home from "./page";
 import { mockBookmarks } from "./test-utils/bookmarkTestUtils";
 
+import { HTTP_STATUS_OK } from "./constants/httpStatusCodes";
+
 const mockFetch = vi.fn();
 
 describe("テスト環境を動作確認するためのサンプルのテスト", () => {
@@ -18,7 +20,7 @@ describe("テスト環境を動作確認するためのサンプルのテスト"
   it("すべてのエレメントが表示されることを確認", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      status: 200,
+      status: HTTP_STATUS_OK,
       json: async () => mockBookmarks,
     });
     render(<Home />);

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -10,7 +10,12 @@ import {
   TITLE_ROLE_NAME,
   URL_ROLE_NAME,
 } from "../constants/constants";
-import { HTTP_STATUS_NO_CONTENT, HTTP_STATUS_OK } from "../constants/httpStatusCodes";
+import {
+  HTTP_STATUS_CREATED,
+  HTTP_STATUS_MULTIPLE_CHOICES,
+  HTTP_STATUS_NO_CONTENT,
+  HTTP_STATUS_OK,
+} from "../constants/httpStatusCodes";
 import { Bookmark } from "../types/Bookmark";
 import { Keyword } from "../types/Keyword";
 
@@ -187,14 +192,15 @@ export const createMockResponse = ({
 }: CreateMockResponseOptions = {}) => {
   const DEFAULT_KEYWORD_ID = 1;
   const DEFAULT_BOOKMARK_KEYWORD_ID = 123;
-  const responseStatus = status ?? 201;
+
+  const responseStatus = status ?? HTTP_STATUS_CREATED;
   const response: {
     ok: boolean;
     status: number;
     json?: () => Promise<Partial<MockResponseJson>>;
     text?: () => Promise<string>;
   } = {
-    ok: isOk ?? (responseStatus >= HTTP_STATUS_OK && responseStatus < 300),
+    ok: isOk ?? (responseStatus >= HTTP_STATUS_OK && responseStatus < HTTP_STATUS_MULTIPLE_CHOICES),
     status: responseStatus,
   };
 

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -10,6 +10,7 @@ import {
   TITLE_ROLE_NAME,
   URL_ROLE_NAME,
 } from "../constants/constants";
+import { HTTP_STATUS_NO_CONTENT, HTTP_STATUS_OK } from "../constants/httpStatusCodes";
 import { Bookmark } from "../types/Bookmark";
 import { Keyword } from "../types/Keyword";
 
@@ -193,12 +194,12 @@ export const createMockResponse = ({
     json?: () => Promise<Partial<MockResponseJson>>;
     text?: () => Promise<string>;
   } = {
-    ok: isOk ?? (responseStatus >= 200 && responseStatus < 300),
+    ok: isOk ?? (responseStatus >= HTTP_STATUS_OK && responseStatus < 300),
     status: responseStatus,
   };
 
   // 204 No Contentのようなボディを持たないレスポンスを考慮
-  if (responseStatus !== 204) {
+  if (responseStatus !== HTTP_STATUS_NO_CONTENT) {
     const body: Partial<MockResponseJson> = {};
     if (message !== undefined) {
       body.message = message;


### PR DESCRIPTION
## 概要
このプルリクエストは、コードベース全体で使用されているHTTPステータスコードを定数として一元管理するようにリファクタリングするものです。マジックナンバーを排除することで、コードの可読性と保守性を向上させることを目的としています。

## 変更内容
- [src/app/constants/httpStatusCodes.ts](code-assist-path:/home/user1/projects/linkpage/src/app/constants/httpStatusCodes.ts) ファイルを新設し、HTTPステータスコードの定数を定義しました。
- APIルートハンドラ、テストコード、ユーティリティ関数（createMockResponseなど）でハードコードされていたHTTPステータスコード（例: 200, 201, 404）を、新しく定義した定数に置き換えました。

## 効果
- 可読性の向上: 409 のような数値が HTTP_STATUS_CONFLICT のような意味のある名前になることで、コードの意図が明確になります。
- 保守性の向上: ステータスコードの管理が一元化されるため、将来の変更や追加が容易かつ安全になります。
- 一貫性の確保: プロジェクト全体で同じ定数を使用することで、コードの一貫性が保たれます。