### PR TITLE
refactor(test): テストコードのブックマークモック参照を定数に変更し可読性と保守性を向上

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.13.2",
+      "version": "1.13.3",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/bookmarks/[bookmark_id]/delete.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/delete.test.ts
@@ -8,7 +8,7 @@ import {
   HTTP_STATUS_NOT_FOUND,
 } from "../../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../../test-utils/assertions";
-import { mockBookmarks } from "../../../test-utils/bookmarkTestUtils";
+import { GOOGLE_BOOKMARK, mockBookmarks } from "../../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../../test-utils/db-setup";
 import { API_BOOKMARKS_URL } from "../../utils/constants";
 import { getDb } from "../database";
@@ -45,7 +45,7 @@ describe("ブックマーク削除APIのテスト (オンメモリDB)", () => {
 
   it("DELETE: ブックマークを削除できる", async () => {
     // 削除対象のブックマーク (例: Google, IDは2になるはず)
-    const bookmarkToDelete = mockBookmarks[1]; // Google
+    const bookmarkToDelete = GOOGLE_BOOKMARK; // Google
 
     // データベースからIDを取得して確認
     const selectStmt = inMemoryDbInstance.prepare(

--- a/src/app/api/bookmarks/[bookmark_id]/get.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/get.test.ts
@@ -8,7 +8,7 @@ import {
   HTTP_STATUS_OK,
 } from "../../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../../test-utils/assertions";
-import { expectEqualBookmark, mockBookmarks } from "../../../test-utils/bookmarkTestUtils";
+import { expectEqualBookmark, GOOGLE_BOOKMARK } from "../../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../../test-utils/db-setup";
 import { API_BOOKMARKS_URL } from "../../utils/constants";
 import { getDb } from "../database";
@@ -46,7 +46,7 @@ describe("ブックマークを1件取得するAPIのテスト", () => {
   });
 
   it("GET: ブックマークのデータが取得できる", async () => {
-    const targetBookmark = mockBookmarks[1];
+    const targetBookmark = GOOGLE_BOOKMARK;
     const [request, context] = createGetRequest(targetBookmark.bookmark_id.toString());
     const response = await GET(request, context);
 

--- a/src/app/api/bookmarks/[bookmark_id]/put.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/put.test.ts
@@ -9,7 +9,11 @@ import {
   HTTP_STATUS_NOT_FOUND,
 } from "../../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../../test-utils/assertions";
-import { mockBookmarks } from "../../../test-utils/bookmarkTestUtils";
+import {
+  GMAIL_BOOKMARK,
+  LINKPAGE_BOOKMARK,
+  mockBookmarks,
+} from "../../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../../test-utils/db-setup";
 import { API_BOOKMARKS_URL } from "../../utils/constants";
 import { getDb } from "../database";
@@ -53,10 +57,10 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
   it("PUT: ブックマークのタイトルのみを更新できる。", async () => {
     const [request, context] = createPutRequest(
       JSON.stringify({
-        url: mockBookmarks[0].url,
+        url: LINKPAGE_BOOKMARK.url,
         title: "Updated Title",
       }),
-      mockBookmarks[0].bookmark_id
+      LINKPAGE_BOOKMARK.bookmark_id
     );
     const response = await PUT(request, context);
 
@@ -67,13 +71,13 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
     const selectStmt = inMemoryDbInstance.prepare(
       "SELECT bookmark_id, url, title FROM bookmarks WHERE bookmark_id = ?"
     );
-    const updatedEntry = selectStmt.get(mockBookmarks[0].bookmark_id) as {
+    const updatedEntry = selectStmt.get(LINKPAGE_BOOKMARK.bookmark_id) as {
       bookmark_id: number;
       url: string;
       title: string;
     };
-    expect(updatedEntry.bookmark_id).toEqual(mockBookmarks[0].bookmark_id);
-    expect(updatedEntry.url).toEqual(mockBookmarks[0].url);
+    expect(updatedEntry.bookmark_id).toEqual(LINKPAGE_BOOKMARK.bookmark_id);
+    expect(updatedEntry.url).toEqual(LINKPAGE_BOOKMARK.url);
     expect(updatedEntry.title).toEqual("Updated Title");
     // 更新後の件数を確認
     const countAfter = (
@@ -284,18 +288,12 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
   });
 
   it("PUT: 同じURLが登録される場合には409を返す。", async () => {
-    const bookmarkToUpdate = {
-      bookmark_id: 1,
-      url: "https://www.example.com",
-      title: "Example Title",
-    };
-
     const [request, context] = createPutRequest(
       JSON.stringify({
-        url: mockBookmarks[2].url,
-        title: bookmarkToUpdate.title,
+        url: GMAIL_BOOKMARK.url,
+        title: "Example Title",
       }),
-      bookmarkToUpdate.bookmark_id
+      LINKPAGE_BOOKMARK.bookmark_id
     );
     const response = await PUT(request, context);
 

--- a/src/app/api/bookmarks/post.test.ts
+++ b/src/app/api/bookmarks/post.test.ts
@@ -9,7 +9,7 @@ import {
   HTTP_STATUS_NO_CONTENT,
 } from "../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../test-utils/assertions";
-import { createBookmark, mockBookmarks } from "../../test-utils/bookmarkTestUtils";
+import { createBookmark, GOOGLE_BOOKMARK } from "../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../test-utils/db-setup";
 import { Bookmark } from "../../types/Bookmark";
 import { API_BOOKMARKS_URL } from "../utils/constants";
@@ -128,7 +128,7 @@ describe("ブックマーク追加APIのテスト (オンメモリDB)", () => {
 
   it("POST: 重複したURLのブックマーク追加時に409 Conflictを返す", async () => {
     const bookmark: Bookmark = createBookmark({
-      url: mockBookmarks[1].url, // Same URL
+      url: GOOGLE_BOOKMARK.url, // Same URL
       title: "同じURLで別のタイトル",
     });
 

--- a/src/app/components/BookmarkManager/delete.test.tsx
+++ b/src/app/components/BookmarkManager/delete.test.tsx
@@ -18,6 +18,7 @@ import {
   assertBookmarkIsSelected,
   clickBookmark,
   createMockResponse,
+  GOOGLE_BOOKMARK,
   mockBookmarks,
   setupBookmarkManagerForTest,
 } from "../../test-utils/bookmarkTestUtils";
@@ -59,7 +60,7 @@ describe("削除ボタン", () => {
 
     beforeEach(async () => {
       // 2番目のブックマーク「Google」を選択
-      bookmarkToSelect = mockBookmarks[1];
+      bookmarkToSelect = GOOGLE_BOOKMARK;
       await clickBookmark(user, bookmarkToSelect);
       await assertBookmarkIsSelected(bookmarkToSelect);
 

--- a/src/app/components/BookmarkManager/hotkeys.test.tsx
+++ b/src/app/components/BookmarkManager/hotkeys.test.tsx
@@ -11,6 +11,7 @@ import {
   assertNoBookmarkIsSelected,
   clickBookmark,
   deselectBookmark,
+  GOOGLE_BOOKMARK,
   keyDown,
   mockBookmarks,
   setBookmarkFormValuesAndClickButton,
@@ -82,7 +83,7 @@ describe("BookmarkManager Hotkeys", () => {
   describe("ブックマークが選択されている場合", () => {
     beforeEach(async () => {
       // 2番目のブックマーク「Google」を選択
-      bookmarkToSelect = mockBookmarks[1]; // Google
+      bookmarkToSelect = GOOGLE_BOOKMARK; // Google
       await clickBookmark(user, bookmarkToSelect);
       await assertBookmarkIsSelected(bookmarkToSelect);
     });

--- a/src/app/components/BookmarkManager/open.test.tsx
+++ b/src/app/components/BookmarkManager/open.test.tsx
@@ -9,6 +9,7 @@ import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   clickBookmark,
+  GOOGLE_BOOKMARK,
   mockBookmarks,
   setBookmarkFormValuesAndEnterKeydown,
   setupBookmarkManagerForTest,
@@ -83,8 +84,8 @@ describe("「開く」ボタン: 入力されたURLを新しいタブで開く",
   describe("ブックマーク選択後", () => {
     beforeEach(async () => {
       // クリックするブックマークを選択（例：2番目のブックマーク）
-      await clickBookmark(user, mockBookmarks[1]);
-      await assertBookmarkIsSelected(mockBookmarks[1]);
+      await clickBookmark(user, GOOGLE_BOOKMARK);
+      await assertBookmarkIsSelected(GOOGLE_BOOKMARK);
     });
 
     it("Enterキーを押した場合", async () => {

--- a/src/app/components/BookmarkManager/parameter.test.tsx
+++ b/src/app/components/BookmarkManager/parameter.test.tsx
@@ -10,6 +10,7 @@ import {
   assertBookmarkIsSelected,
   clickBookmark,
   expectBookmarkFormValues,
+  GOOGLE_BOOKMARK,
   mockBookmarks,
   setBookmarkFormValuesAndClickButton,
   setupBookmarkManagerForTest,
@@ -34,7 +35,7 @@ describe("「パラメータ」ボタン: URLから無駄な文字列を削除�
 
       await setupBookmarkManagerForTest();
 
-      const bookmarkToSelect = mockBookmarks[1]; // Google
+      const bookmarkToSelect = GOOGLE_BOOKMARK; // Google
       await clickBookmark(user, bookmarkToSelect);
       await assertBookmarkIsSelected(bookmarkToSelect);
     });

--- a/src/app/components/BookmarkManager/path.test.tsx
+++ b/src/app/components/BookmarkManager/path.test.tsx
@@ -10,6 +10,7 @@ import {
   assertBookmarkIsSelected,
   clickBookmark,
   expectBookmarkFormValues,
+  GOOGLE_BOOKMARK,
   mockBookmarks,
   setBookmarkFormValuesAndClickButton,
   setupBookmarkManagerForTest,
@@ -33,8 +34,8 @@ describe("「←」ボタン", () => {
 
     await setupBookmarkManagerForTest();
 
-    await clickBookmark(user, mockBookmarks[1]);
-    await assertBookmarkIsSelected(mockBookmarks[1]);
+    await clickBookmark(user, GOOGLE_BOOKMARK);
+    await assertBookmarkIsSelected(GOOGLE_BOOKMARK);
   });
 
   it.each([

--- a/src/app/components/BookmarkManager/select.test.tsx
+++ b/src/app/components/BookmarkManager/select.test.tsx
@@ -11,6 +11,7 @@ import {
   clickBookmark,
   createBookmark,
   deselectBookmark,
+  GOOGLE_BOOKMARK,
   mockBookmarks,
   setupBookmarkManagerForTest,
 } from "../../test-utils/bookmarkTestUtils";
@@ -40,7 +41,7 @@ describe("ブックマークの選択", () => {
 
   it("選択解除のボタンをクリックすると、URLとタイトルのテキストボックスがクリアされる。選択解除のボタンが表示されていない。", async () => {
     // クリックするブックマークを選択（例：2番目のブックマーク）
-    const bookmarkToSelect = mockBookmarks[1]; // Google
+    const bookmarkToSelect = GOOGLE_BOOKMARK; // Google
     await clickBookmark(user, bookmarkToSelect);
     await assertBookmarkIsSelected(bookmarkToSelect);
 

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -21,6 +21,8 @@ import {
   createBookmark,
   createMockResponse,
   expectBookmarkFormValues,
+  GMAIL_BOOKMARK,
+  GOOGLE_BOOKMARK,
   mockBookmarks,
   setBookmarkFormValuesAndClickButton,
   setupBookmarkManagerForTest,
@@ -61,7 +63,7 @@ describe("タイトルの更新ボタン", () => {
     let bookmarkToSelect: Bookmark;
     beforeEach(async () => {
       // 2番目のブックマーク「Google」を選択
-      bookmarkToSelect = mockBookmarks[1];
+      bookmarkToSelect = GOOGLE_BOOKMARK;
       await clickBookmark(user, bookmarkToSelect);
       await assertBookmarkIsSelected(bookmarkToSelect);
       mockFetch.mockReset();
@@ -133,7 +135,7 @@ describe("タイトルの更新ボタン", () => {
       });
 
       it("同じURLを指定された場合には409を返す。", async () => {
-        const updateUrl = mockBookmarks[2].url;
+        const updateUrl = GMAIL_BOOKMARK.url;
         const updateTitle = "更新されたタイトル";
         const errorText = "指定されたURLのブックマークは既に登録されています。";
         const statusCode = HTTP_STATUS_CONFLICT;

--- a/src/app/components/BookmarkTable.test.tsx
+++ b/src/app/components/BookmarkTable.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 
 import { TABLE_NAME_BOOKMARKS } from "../constants/constants";
-import { mockBookmarks } from "../test-utils/bookmarkTestUtils";
+import { GOOGLE_BOOKMARK, mockBookmarks } from "../test-utils/bookmarkTestUtils";
 import { BookmarkTable } from "./BookmarkTable";
 
 describe("BookmarkTableのテスト", () => {
@@ -80,7 +80,7 @@ describe("BookmarkTableのテスト", () => {
 
   it("選択されたブックマークが正しくハイライト表示される", () => {
     const mockOnSelectBookmark = vi.fn<(bookmarkId: number) => void>();
-    const selected = mockBookmarks[1]; // "Google" を選択状態にする
+    const selected = GOOGLE_BOOKMARK; // "Google" を選択状態にする
 
     render(
       <BookmarkTable

--- a/src/app/hooks/useBookmarkManager.test.tsx
+++ b/src/app/hooks/useBookmarkManager.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 
 import { HTTP_STATUS_CREATED, HTTP_STATUS_OK } from "../constants/httpStatusCodes";
-import { mockBookmarks } from "../test-utils/bookmarkTestUtils";
+import { LINKPAGE_BOOKMARK, mockBookmarks } from "../test-utils/bookmarkTestUtils";
 import { useBookmarkManager } from "./useBookmarkManager";
 
 const mockFetch = vi.fn();
@@ -64,12 +64,12 @@ describe("useBookmarkManager", () => {
 
     // 3. ブックマークを選択する
     act(() => {
-      result.current.setSelectedBookmarkId(mockBookmarks[0].bookmark_id);
+      result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
     });
 
     // 4. ブックマーク選択による副作用(useEffect)が完了し、フォームが更新されるのを待つ
     await waitFor(() => {
-      expect(result.current.textUrl).toBe(mockBookmarks[0].url);
+      expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
     });
 
     // 5. キーワードを入力し、追加アクションを実行する
@@ -87,7 +87,7 @@ describe("useBookmarkManager", () => {
 
       // bookmarks ステートが更新され、新しいキーワードが追加されていることを確認
       const updatedBookmark = result.current.bookmarks.find(
-        (b) => b.bookmark_id === mockBookmarks[0].bookmark_id
+        (b) => b.bookmark_id === LINKPAGE_BOOKMARK.bookmark_id
       );
       expect(updatedBookmark?.keywords).toContainEqual(newKeywordResponse);
     });

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -36,37 +36,33 @@ export function createBookmark({
   return { bookmark_id, url, title, keywords };
 }
 
-export function createBookmarkList(bookmarkList: Partial<Bookmark>[]) {
-  return bookmarkList.map(createBookmark);
-}
+export const LINKPAGE_BOOKMARK: Bookmark = createBookmark({
+  bookmark_id: 1,
+  url: "https://github.com/kubotama/linkpage",
+  title: "kubotama/linkpage",
+});
+export const GOOGLE_BOOKMARK: Bookmark = createBookmark({
+  bookmark_id: 2,
+  url: "https://www.google.com/",
+  title: "Google",
+});
+export const GMAIL_BOOKMARK: Bookmark = createBookmark({
+  bookmark_id: 3,
+  url: "https://mail.google.com",
+  title: "Gmail",
+});
+export const AMAZON_BOOKMARK: Bookmark = createBookmark({
+  bookmark_id: 4,
+  url: "https://www.amazon.co.jp/",
+  title: "Amazon",
+});
 
-export const mockBookmarks: Bookmark[] = createBookmarkList([
-  {
-    bookmark_id: 1,
-    url: "https://github.com/kubotama/linkpage",
-    title: "kubotama/linkpage",
-  },
-  {
-    bookmark_id: 2,
-    url: "https://www.google.com/",
-    title: "Google",
-  },
-  {
-    bookmark_id: 3,
-    url: "https://mail.google.com",
-    title: "Gmail",
-  },
-  {
-    bookmark_id: 4,
-    url: "https://www.amazon.co.jp/",
-    title: "Amazon",
-  },
-]);
-
-export const LINKPAGE_BOOKMARK = mockBookmarks[0];
-export const GOOGLE_BOOKMARK = mockBookmarks[1];
-export const GMAIL_BOOKMARK = mockBookmarks[2];
-export const AMAZON_BOOKMARK = mockBookmarks[3];
+export const mockBookmarks: Bookmark[] = [
+  LINKPAGE_BOOKMARK,
+  GOOGLE_BOOKMARK,
+  GMAIL_BOOKMARK,
+  AMAZON_BOOKMARK,
+];
 
 export const assertBookmarkIsSelected = async (bookmark: Bookmark) => {
   await waitFor(() => {

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -63,6 +63,11 @@ export const mockBookmarks: Bookmark[] = createBookmarkList([
   },
 ]);
 
+export const LINKPAGE_BOOKMARK = mockBookmarks[0];
+export const GOOGLE_BOOKMARK = mockBookmarks[1];
+export const GMAIL_BOOKMARK = mockBookmarks[2];
+export const AMAZON_BOOKMARK = mockBookmarks[3];
+
 export const assertBookmarkIsSelected = async (bookmark: Bookmark) => {
   await waitFor(() => {
     expect(screen.getByRole("textbox", { name: URL_ROLE_NAME })).toHaveValue(bookmark.url);
@@ -84,8 +89,6 @@ export const getCellWithTitle = (title: string) => {
 };
 
 export const clickBookmark = async (user: UserEvent, bookmark: Bookmark) => {
-  // クリックするブックマークを選択（例：2番目のブックマーク）
-  // const bookmark = mockBookmarks[1]; // Google
   try {
     const cellWithTitle = getCellWithTitle(bookmark.title);
     const row = cellWithTitle.closest("tr");
@@ -292,7 +295,7 @@ export const setBookmarkFormValuesAndEnterKeydown = async (user: UserEvent, url:
  */
 export const setupBookmarkManagerForTest = async () => {
   render(<BookmarkManager />);
-  await screen.findByRole("cell", { name: mockBookmarks[0].title });
+  await screen.findByRole("cell", { name: LINKPAGE_BOOKMARK.title });
 };
 
 export const deselectBookmark = async (user: UserEvent) => {


### PR DESCRIPTION
## 概要
テストコード全体で、ブックマークのモックデータをインデックス（例: mockBookmarks[0]）で参照していた箇所を、名前付きの定数（例: LINKPAGE_BOOKMARK）で参照するようにリファクタリングしました。

## 変更理由
これまでのインデックスベースの参照には、以下の課題がありました。

- 可読性の低下: mockBookmarks[0] が具体的にどのブックマークを指しているのかがコードから直感的に分からず、定義元を確認する必要がありました。
- 保守性の低下: mockBookmarks 配列の順序を変更した場合、テストが意図せず失敗する可能性があり、変更に弱い状態でした。

今回の変更により、テスト対象が明確になり、将来のデータ構造の変更にも強い、堅牢なテストコードになります。

## 変更内容
- [src/app/test-utils/bookmarkTestUtils.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/test-utils/bookmarkTestUtils.tsx) に、各モックブックマークに対応する名前付き定数をエクスポートするよう追加しました。
- 各テストファイル (*.test.ts, *.test.tsx) で、インデックスによる参照を、新しく定義した定数による参照にすべて置き換えました。

## 影響範囲
この変更はテストコードのみを対象としており、アプリケーションの動作やビルド後の成果物には一切影響ありません。

fixes: #256 