### PR TITLE
refactor(test): エラーメッセージのテストアサーションを共通化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.13.3",
+      "version": "1.13.4",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/components/BookmarkManager/delete.test.tsx
+++ b/src/app/components/BookmarkManager/delete.test.tsx
@@ -16,6 +16,7 @@ import {
 } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
+  assertErrorMessage,
   clickBookmark,
   createMockResponse,
   GOOGLE_BOOKMARK,
@@ -129,11 +130,11 @@ describe("削除ボタン", () => {
         `ApiError: [${errorCase.status}] ${errorCase.message}`
       );
 
-      expect(await screen.findByTestId("bookmark-message")).toHaveTextContent(
-        "ブックマークの削除中にエラーが発生しました。"
-      );
-      await screen.findByText(bookmarkToSelect.title);
-      await screen.findByRole("button", { name: DELETE_BUTTON_ROLE_NAME });
+      await assertErrorMessage({
+        message: "ブックマークの削除中にエラーが発生しました。",
+        isError: true,
+        isWait: true,
+      });
 
       consoleErrorSpy.mockRestore();
     });

--- a/src/app/components/BookmarkManager/delete.test.tsx
+++ b/src/app/components/BookmarkManager/delete.test.tsx
@@ -121,23 +121,26 @@ describe("削除ボタン", () => {
       },
     ])("エラーハンドリング: $description", async ({ errorCase }) => {
       const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        mockFetch.mockResolvedValueOnce(createMockResponse({ ...errorCase, isOk: false }));
+        await clickDeleteButton(user);
 
-      mockFetch.mockResolvedValueOnce(createMockResponse({ ...errorCase, isOk: false }));
-      await clickDeleteButton(user);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          "ブックマークの削除エラー:",
+          `ApiError: [${errorCase.status}] ${errorCase.message}`
+        );
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "ブックマークの削除エラー:",
-        `ApiError: [${errorCase.status}] ${errorCase.message}`
-      );
+        await assertErrorMessage({
+          message: "ブックマークの削除中にエラーが発生しました。",
+          isError: true,
+          isWait: true,
+        });
 
-      await assertErrorMessage({
-        message: "ブックマークの削除中にエラーが発生しました。",
-        isError: true,
-        isWait: true,
-      });
-
-      await screen.findByText(bookmarkToSelect.title);
-      await screen.findByRole("button", { name: DELETE_BUTTON_ROLE_NAME });
+        await screen.findByText(bookmarkToSelect.title);
+        await screen.findByRole("button", { name: DELETE_BUTTON_ROLE_NAME });
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
     });
   });
 });

--- a/src/app/components/BookmarkManager/delete.test.tsx
+++ b/src/app/components/BookmarkManager/delete.test.tsx
@@ -136,7 +136,8 @@ describe("削除ボタン", () => {
         isWait: true,
       });
 
-      consoleErrorSpy.mockRestore();
+      await screen.findByText(bookmarkToSelect.title);
+      await screen.findByRole("button", { name: DELETE_BUTTON_ROLE_NAME });
     });
   });
 });

--- a/src/app/components/BookmarkManager/delete.test.tsx
+++ b/src/app/components/BookmarkManager/delete.test.tsx
@@ -133,7 +133,7 @@ describe("削除ボタン", () => {
         await assertErrorMessage({
           message: "ブックマークの削除中にエラーが発生しました。",
           isError: true,
-          isWait: true,
+          isAsync: true,
         });
 
         await screen.findByText(bookmarkToSelect.title);

--- a/src/app/components/BookmarkManager/hotkeys.test.tsx
+++ b/src/app/components/BookmarkManager/hotkeys.test.tsx
@@ -2,12 +2,13 @@ import "@testing-library/jest-dom";
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { screen, waitFor } from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 
 import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
+  assertErrorMessage,
   assertNoBookmarkIsSelected,
   clickBookmark,
   deselectBookmark,
@@ -109,9 +110,11 @@ describe("BookmarkManager Hotkeys", () => {
       await keyDown(user, "{enter}");
 
       // エラーメッセージが表示され、window.openが呼び出されていないことを検証
-      expect(await screen.findByTestId("bookmark-message")).toHaveTextContent(
-        "URLが無効です。正しいURLを入力してください。"
-      );
+      await assertErrorMessage({
+        message: "URLが無効です。正しいURLを入力してください。",
+        isError: true,
+        isWait: true,
+      });
       expect(mockOpen).not.toHaveBeenCalled();
     });
 

--- a/src/app/components/BookmarkManager/hotkeys.test.tsx
+++ b/src/app/components/BookmarkManager/hotkeys.test.tsx
@@ -113,7 +113,7 @@ describe("BookmarkManager Hotkeys", () => {
       await assertErrorMessage({
         message: "URLが無効です。正しいURLを入力してください。",
         isError: true,
-        isWait: true,
+        isAsync: true,
       });
       expect(mockOpen).not.toHaveBeenCalled();
     });

--- a/src/app/components/BookmarkManager/open.test.tsx
+++ b/src/app/components/BookmarkManager/open.test.tsx
@@ -106,7 +106,7 @@ describe("「開く」ボタン: 入力されたURLを新しいタブで開く",
       await assertErrorMessage({
         message: "URLが無効です。正しいURLを入力してください。",
         isError: true,
-        isWait: true,
+        isAsync: true,
       });
 
       expect(mockOpen).not.toHaveBeenCalled();

--- a/src/app/components/BookmarkManager/open.test.tsx
+++ b/src/app/components/BookmarkManager/open.test.tsx
@@ -2,12 +2,13 @@ import "@testing-library/jest-dom";
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { screen, waitFor } from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 
 import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
+  assertErrorMessage,
   clickBookmark,
   GOOGLE_BOOKMARK,
   mockBookmarks,
@@ -102,9 +103,12 @@ describe("「開く」ボタン: 入力されたURLを新しいタブで開く",
     it("不正なURLを入力した場合", async () => {
       await setBookmarkFormValuesAndEnterKeydown(user, "invalid-url");
 
-      expect(await screen.findByTestId("bookmark-message")).toHaveTextContent(
-        "URLが無効です。正しいURLを入力してください。"
-      );
+      await assertErrorMessage({
+        message: "URLが無効です。正しいURLを入力してください。",
+        isError: true,
+        isWait: true,
+      });
+
       expect(mockOpen).not.toHaveBeenCalled();
     });
   });

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -169,7 +169,7 @@ describe("タイトルの更新ボタン", () => {
         await assertErrorMessage({
           message: "指定されたURLのブックマークは既に登録されています。",
           isError: true,
-          isWait: true,
+          isAsync: true,
         });
         const table = await screen.findByRole("table", { name: TABLE_NAME_BOOKMARKS });
         await within(table).findByText(bookmarkToSelect.title);
@@ -224,7 +224,7 @@ describe("タイトルの更新ボタン", () => {
         await assertErrorMessage({
           message: "ブックマークの更新中にエラーが発生しました。",
           isError: true,
-          isWait: true,
+          isAsync: true,
         });
       });
 
@@ -256,7 +256,7 @@ describe("タイトルの更新ボタン", () => {
         await assertErrorMessage({
           message: "ブックマークの更新中にエラーが発生しました。",
           isError: true,
-          isWait: true,
+          isAsync: true,
         });
       });
     });

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
+  assertErrorMessage,
   clickBookmark,
   createBookmark,
   createMockResponse,
@@ -165,9 +166,11 @@ describe("タイトルの更新ボタン", () => {
           title: updateTitle,
           buttonName: UPDATE_BUTTON_ROLE_NAME,
         });
-        expect(await screen.findByTestId("bookmark-message")).toHaveTextContent(
-          "指定されたURLのブックマークは既に登録されています。"
-        );
+        await assertErrorMessage({
+          message: "指定されたURLのブックマークは既に登録されています。",
+          isError: true,
+          isWait: true,
+        });
         const table = await screen.findByRole("table", { name: TABLE_NAME_BOOKMARKS });
         await within(table).findByText(bookmarkToSelect.title);
       });
@@ -218,9 +221,11 @@ describe("タイトルの更新ボタン", () => {
           buttonName: UPDATE_BUTTON_ROLE_NAME,
         });
 
-        expect(await screen.findByTestId("bookmark-message")).toHaveTextContent(
-          "ブックマークの更新中にエラーが発生しました。"
-        );
+        await assertErrorMessage({
+          message: "ブックマークの更新中にエラーが発生しました。",
+          isError: true,
+          isWait: true,
+        });
       });
 
       it.each([
@@ -248,9 +253,11 @@ describe("タイトルの更新ボタン", () => {
           buttonName: UPDATE_BUTTON_ROLE_NAME,
         });
 
-        expect(await screen.findByTestId("bookmark-message")).toHaveTextContent(
-          "ブックマークの更新中にエラーが発生しました。"
-        );
+        await assertErrorMessage({
+          message: "ブックマークの更新中にエラーが発生しました。",
+          isError: true,
+          isWait: true,
+        });
       });
     });
   });

--- a/src/app/components/BookmarkManager/view.test.tsx
+++ b/src/app/components/BookmarkManager/view.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 import { HTTP_STATUS_INTERNAL_SERVER_ERROR, HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
-import { mockBookmarks } from "../../test-utils/bookmarkTestUtils";
+import { assertErrorMessage, mockBookmarks } from "../../test-utils/bookmarkTestUtils";
 import { BookmarkManager } from "../BookmarkManager";
 
 const mockFetch = vi.fn();
@@ -38,7 +38,7 @@ describe("BookmarkManagerの表示を確認", () => {
 
     render(<BookmarkManager />);
 
-    expect(screen.getByTestId("bookmark-message")).toHaveTextContent(/^ブックマークをロード中...$/);
+    assertErrorMessage({ message: "ブックマークをロード中...", isError: false, isWait: false });
   });
 
   it("HTTPステータス500でfetchした場合、エラーメッセージが表示される", async () => {
@@ -55,8 +55,11 @@ describe("BookmarkManagerの表示を確認", () => {
 
     render(<BookmarkManager />);
 
-    const errorMessage = await screen.findByTestId("bookmark-message");
-    expect(errorMessage).toHaveTextContent(/ブックマークのロード中にエラーが発生しました。/);
+    await assertErrorMessage({
+      message: "ブックマークのロード中にエラーが発生しました。",
+      isError: true,
+      isWait: true,
+    });
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       "ブックマークのロードエラー:",

--- a/src/app/components/BookmarkManager/view.test.tsx
+++ b/src/app/components/BookmarkManager/view.test.tsx
@@ -47,29 +47,31 @@ describe("BookmarkManagerの表示を確認", () => {
 
   it("HTTPステータス500でfetchした場合、エラーメッセージが表示される", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const errorText = "Internal Error";
-    const statusCode = HTTP_STATUS_INTERNAL_SERVER_ERROR;
+    try {
+      const errorText = "Internal Error";
+      const statusCode = HTTP_STATUS_INTERNAL_SERVER_ERROR;
 
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: statusCode,
-      headers: { "Content-Type": "application/json" },
-      text: async () => JSON.stringify({ message: errorText }),
-    });
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: statusCode,
+        headers: { "Content-Type": "application/json" },
+        text: async () => JSON.stringify({ message: errorText }),
+      });
 
-    render(<BookmarkManager />);
+      render(<BookmarkManager />);
 
-    await assertErrorMessage({
-      message: "ブックマークのロード中にエラーが発生しました。",
-      isError: true,
-      isWait: true,
-    });
+      await assertErrorMessage({
+        message: "ブックマークのロード中にエラーが発生しました。",
+        isError: true,
+        isWait: true,
+      });
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "ブックマークのロードエラー:",
-      `ApiError: [${statusCode}] ${errorText}`
-    );
-
-    consoleErrorSpy.mockRestore();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "ブックマークのロードエラー:",
+        `ApiError: [${statusCode}] ${errorText}`
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 });

--- a/src/app/components/BookmarkManager/view.test.tsx
+++ b/src/app/components/BookmarkManager/view.test.tsx
@@ -29,7 +29,7 @@ describe("BookmarkManagerの表示を確認", () => {
     expect(bm).toBeVisible();
   });
 
-  it("ローディング中にローディングメッセージが表示されること", () => {
+  it("ローディング中にローディングメッセージが表示されること", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: HTTP_STATUS_OK,
@@ -38,7 +38,11 @@ describe("BookmarkManagerの表示を確認", () => {
 
     render(<BookmarkManager />);
 
-    assertErrorMessage({ message: "ブックマークをロード中...", isError: false, isWait: false });
+    await assertErrorMessage({
+      message: "ブックマークをロード中...",
+      isError: false,
+      isWait: false,
+    });
   });
 
   it("HTTPステータス500でfetchした場合、エラーメッセージが表示される", async () => {

--- a/src/app/components/BookmarkManager/view.test.tsx
+++ b/src/app/components/BookmarkManager/view.test.tsx
@@ -41,7 +41,7 @@ describe("BookmarkManagerの表示を確認", () => {
     await assertErrorMessage({
       message: "ブックマークをロード中...",
       isError: false,
-      isWait: false,
+      isAsync: false,
     });
   });
 
@@ -63,7 +63,7 @@ describe("BookmarkManagerの表示を確認", () => {
       await assertErrorMessage({
         message: "ブックマークのロード中にエラーが発生しました。",
         isError: true,
-        isWait: true,
+        isAsync: true,
       });
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(

--- a/src/app/components/ErrorMessage.test.tsx
+++ b/src/app/components/ErrorMessage.test.tsx
@@ -29,7 +29,7 @@ describe("ErrorMessage", () => {
       />
     );
 
-    await assertErrorMessage({ message: textMessage, isError: false, isWait: false });
+    await assertErrorMessage({ message: textMessage, isError: false, isAsync: false });
   });
 
   it("should display error message and close button when there is an error", async () => {
@@ -44,7 +44,7 @@ describe("ErrorMessage", () => {
         handleErrorClose={handleErrorClose}
       />
     );
-    await assertErrorMessage({ message: textMessage, isError: true, isWait: false });
+    await assertErrorMessage({ message: textMessage, isError: true, isAsync: false });
   });
 
   it("should call handleErrorClose when close button is clicked", async () => {

--- a/src/app/components/ErrorMessage.test.tsx
+++ b/src/app/components/ErrorMessage.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"; // Vitestから�
 import { render, screen } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 
+import { assertErrorMessage } from "../test-utils/bookmarkTestUtils";
 import { ErrorMessage } from "./ErrorMessage";
 
 describe("ErrorMessage", () => {
@@ -28,9 +29,7 @@ describe("ErrorMessage", () => {
       />
     );
 
-    expect(screen.getByTestId("bookmark-message")).toHaveTextContent("ブックマークをロード中...");
-    expect(screen.getByTestId("bookmark-message")).not.toHaveStyle("color: red");
-    expect(screen.queryByRole("button", { name: "閉じる" })).not.toBeInTheDocument();
+    await assertErrorMessage({ message: textMessage, isError: false, isWait: false });
   });
 
   it("should display error message and close button when there is an error", () => {
@@ -45,10 +44,7 @@ describe("ErrorMessage", () => {
         handleErrorClose={handleErrorClose}
       />
     );
-    const errorMessageElement = screen.getByTestId("bookmark-message");
-    expect(errorMessageElement).toHaveTextContent("エラーが発生しました");
-    expect(errorMessageElement).toHaveClass("text-red-500");
-    expect(screen.getByRole("button", { name: "閉じる" })).toBeVisible();
+    assertErrorMessage({ message: textMessage, isError: true, isWait: false });
   });
 
   it("should call handleErrorClose when close button is clicked", async () => {

--- a/src/app/components/ErrorMessage.test.tsx
+++ b/src/app/components/ErrorMessage.test.tsx
@@ -32,7 +32,7 @@ describe("ErrorMessage", () => {
     await assertErrorMessage({ message: textMessage, isError: false, isWait: false });
   });
 
-  it("should display error message and close button when there is an error", () => {
+  it("should display error message and close button when there is an error", async () => {
     const textMessage = "エラーが発生しました";
     const isError = true;
     const handleErrorClose = vi.fn();
@@ -44,7 +44,7 @@ describe("ErrorMessage", () => {
         handleErrorClose={handleErrorClose}
       />
     );
-    assertErrorMessage({ message: textMessage, isError: true, isWait: false });
+    await assertErrorMessage({ message: textMessage, isError: true, isWait: false });
   });
 
   it("should call handleErrorClose when close button is clicked", async () => {

--- a/src/app/components/ErrorMessage.tsx
+++ b/src/app/components/ErrorMessage.tsx
@@ -20,7 +20,10 @@ export const ErrorMessage = ({
           {isError && ( // エラーメッセージがある場合のみ「閉じる」ボタンを表示
             <ActionButton onClick={handleErrorClose}>閉じる</ActionButton>
           )}
-          <div data-testid="bookmark-message" className={`ml-2 ${isError ? "text-red-500" : ""}`}>
+          <div
+            data-testid="bookmark-message"
+            className={`ml-2 ${isError ? "text-red-500" : "text-gray-800"}`}
+          >
             {textMessage}
           </div>
         </>

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -309,32 +309,26 @@ export const assertErrorMessage = async ({
   isError,
   isWait,
 }: AssertErrorMessageOptions) => {
-  let errorElement: HTMLElement;
-  if (isWait) {
-    errorElement = await screen.findByTestId("bookmark-message");
-  } else {
-    errorElement = screen.getByTestId("bookmark-message");
-  }
+  const errorElement = isWait
+    ? await screen.findByTestId("bookmark-message")
+    : screen.getByTestId("bookmark-message");
   expect(errorElement).toBeInTheDocument();
   expect(errorElement).toHaveTextContent(message);
 
   if (isError) {
     expect(errorElement).toHaveClass("text-red-500");
     expect(errorElement).not.toHaveClass("text-gray-800");
-    if (isWait) {
-      expect(await screen.findByRole("button", { name: "閉じる" })).toBeVisible();
-    } else {
-      expect(screen.getByRole("button", { name: "閉じる" })).toBeVisible();
-    }
+    const closeButton = isWait
+      ? await screen.findByRole("button", { name: "閉じる" })
+      : screen.getByRole("button", { name: "閉じる" });
+    expect(closeButton).toBeVisible();
   } else {
     expect(errorElement).not.toHaveClass("text-red-500");
     expect(errorElement).toHaveClass("text-gray-800");
-    if (isWait) {
-      await waitFor(() => {
-        expect(screen.queryByRole("button", { name: "閉じる" })).not.toBeInTheDocument();
-      });
-    } else {
+    // isWait の場合、要素が非同期で消えるのを待つ必要がある。
+    // isWait でない場合でも、waitFor はすぐに解決されるため、コードを統一できる。
+    await waitFor(() => {
       expect(screen.queryByRole("button", { name: "閉じる" })).not.toBeInTheDocument();
-    }
+    });
   }
 };

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -312,7 +312,6 @@ export const assertErrorMessage = async ({
   const messageElement = isAsync
     ? await screen.findByTestId("bookmark-message")
     : screen.getByTestId("bookmark-message");
-  expect(messageElement).toBeInTheDocument();
   expect(messageElement).toHaveTextContent(message);
 
   if (isError) {
@@ -322,8 +321,8 @@ export const assertErrorMessage = async ({
   } else {
     expect(messageElement).not.toHaveClass("text-red-500");
     expect(messageElement).toHaveClass("text-gray-800");
-// 「閉じる」ボタンは非同期で消える可能性があるため、isAsyncの値に関わらず
-// waitForを使用して、ボタンが確実に存在しないことを検証します。
+    // 「閉じる」ボタンは非同期で消える可能性があるため、isAsyncの値に関わらず
+    // waitForを使用して、ボタンが確実に存在しないことを検証します。
     await waitFor(() => {
       expect(screen.queryByRole("button", { name: "閉じる" })).not.toBeInTheDocument();
     });

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -330,7 +330,7 @@ export const assertErrorMessage = async ({
     expect(errorElement).not.toHaveClass("text-red-500");
     expect(errorElement).toHaveClass("text-gray-800");
     if (isWait) {
-      waitFor(() => {
+      await waitFor(() => {
         expect(screen.queryByRole("button", { name: "閉じる" })).not.toBeInTheDocument();
       });
     } else {

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -322,8 +322,8 @@ export const assertErrorMessage = async ({
   } else {
     expect(messageElement).not.toHaveClass("text-red-500");
     expect(messageElement).toHaveClass("text-gray-800");
-    // isWait の場合、要素が非同期で消えるのを待つ必要がある。
-    // isWait でない場合でも、waitFor はすぐに解決されるため、コードを統一できる。
+// 「閉じる」ボタンは非同期で消える可能性があるため、isAsyncの値に関わらず
+// waitForを使用して、ボタンが確実に存在しないことを検証します。
     await waitFor(() => {
       expect(screen.queryByRole("button", { name: "閉じる" })).not.toBeInTheDocument();
     });

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -309,22 +309,19 @@ export const assertErrorMessage = async ({
   isError,
   isWait,
 }: AssertErrorMessageOptions) => {
-  const errorElement = isWait
+  const messageElement = isWait
     ? await screen.findByTestId("bookmark-message")
     : screen.getByTestId("bookmark-message");
-  expect(errorElement).toBeInTheDocument();
-  expect(errorElement).toHaveTextContent(message);
+  expect(messageElement).toBeInTheDocument();
+  expect(messageElement).toHaveTextContent(message);
 
   if (isError) {
-    expect(errorElement).toHaveClass("text-red-500");
-    expect(errorElement).not.toHaveClass("text-gray-800");
-    const closeButton = isWait
-      ? await screen.findByRole("button", { name: "閉じる" })
-      : screen.getByRole("button", { name: "閉じる" });
-    expect(closeButton).toBeVisible();
+    expect(messageElement).toHaveClass("text-red-500");
+    expect(messageElement).not.toHaveClass("text-gray-800");
+    expect(screen.getByRole("button", { name: "閉じる" })).toBeVisible();
   } else {
-    expect(errorElement).not.toHaveClass("text-red-500");
-    expect(errorElement).toHaveClass("text-gray-800");
+    expect(messageElement).not.toHaveClass("text-red-500");
+    expect(messageElement).toHaveClass("text-gray-800");
     // isWait の場合、要素が非同期で消えるのを待つ必要がある。
     // isWait でない場合でも、waitFor はすぐに解決されるため、コードを統一できる。
     await waitFor(() => {

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -301,15 +301,15 @@ export const deselectBookmark = async (user: UserEvent) => {
 interface AssertErrorMessageOptions {
   message: string;
   isError: boolean;
-  isWait: boolean;
+  isAsync: boolean;
 }
 
 export const assertErrorMessage = async ({
   message,
   isError,
-  isWait,
+  isAsync,
 }: AssertErrorMessageOptions) => {
-  const messageElement = isWait
+  const messageElement = isAsync
     ? await screen.findByTestId("bookmark-message")
     : screen.getByTestId("bookmark-message");
   expect(messageElement).toBeInTheDocument();

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -297,3 +297,44 @@ export const setupBookmarkManagerForTest = async () => {
 export const deselectBookmark = async (user: UserEvent) => {
   await keyDown(user, "{escape}");
 };
+
+interface AssertErrorMessageOptions {
+  message: string;
+  isError: boolean;
+  isWait: boolean;
+}
+
+export const assertErrorMessage = async ({
+  message,
+  isError,
+  isWait,
+}: AssertErrorMessageOptions) => {
+  let errorElement: HTMLElement;
+  if (isWait) {
+    errorElement = await screen.findByTestId("bookmark-message");
+  } else {
+    errorElement = screen.getByTestId("bookmark-message");
+  }
+  expect(errorElement).toBeInTheDocument();
+  expect(errorElement).toHaveTextContent(message);
+
+  if (isError) {
+    expect(errorElement).toHaveClass("text-red-500");
+    expect(errorElement).not.toHaveClass("text-gray-800");
+    if (isWait) {
+      expect(await screen.findByRole("button", { name: "閉じる" })).toBeVisible();
+    } else {
+      expect(screen.getByRole("button", { name: "閉じる" })).toBeVisible();
+    }
+  } else {
+    expect(errorElement).not.toHaveClass("text-red-500");
+    expect(errorElement).toHaveClass("text-gray-800");
+    if (isWait) {
+      waitFor(() => {
+        expect(screen.queryByRole("button", { name: "閉じる" })).not.toBeInTheDocument();
+      });
+    } else {
+      expect(screen.queryByRole("button", { name: "閉じる" })).not.toBeInTheDocument();
+    }
+  }
+};


### PR DESCRIPTION
## 概要
エラーメッセージコンポーネント (ErrorMessage) に関するテストのアサーションロジックを共通ヘルパー関数 assertErrorMessage に集約し、テストコードの品質を向上させました。

## 変更点
- テストヘルパーの追加:

  - test-utils/bookmarkTestUtils.tsx に、エラーメッセージとそれに関連するUIの状態（色、閉じるボタンの表示/非表示）を検証するための assertErrorMessage ヘルパー関数を新たに追加しました。

- テストコードのリファクタリング:

  - BookmarkManager/update.test.tsx と BookmarkManager/view.test.tsx 内の冗長なアサーションを、新しく作成した assertErrorMessage を使用するように置き換えました。これにより、テストの可読性と保守性が向上しています。

- UIコンポーネントの修正:

  - [ErrorMessage.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/components/ErrorMessage.tsx) コンポーネントにおいて、エラーでない通常メッセージが表示される際のテキストカラーとして text-gray-800 を明示的に指定しました。これにより、メッセージの状態が視覚的に一貫性を持つようになりました。

## 目的
- テストコードの重複を削減する。
- テストの意図を明確にし、可読性を高める。
- 将来の仕様変更に対するテストのメンテナンスコストを低減する。

fixes: #247 