### PR TITLE
refactor(test): ボタンクリック処理を共通化しテストの保守性を向上

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.13.4",
+      "version": "1.13.5",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/components/BookmarkManager/delete.test.tsx
+++ b/src/app/components/BookmarkManager/delete.test.tsx
@@ -18,6 +18,7 @@ import {
   assertBookmarkIsSelected,
   assertErrorMessage,
   clickBookmark,
+  clickButtonByName,
   createMockResponse,
   GOOGLE_BOOKMARK,
   mockBookmarks,
@@ -26,14 +27,6 @@ import {
 import { Bookmark } from "../../types/Bookmark";
 
 const mockFetch = vi.fn();
-
-const clickDeleteButton = async (user: UserEvent) => {
-  const deleteButton = screen.getByRole("button", {
-    name: DELETE_BUTTON_ROLE_NAME,
-  });
-
-  await user.click(deleteButton);
-};
 
 describe("削除ボタン", () => {
   let user: UserEvent;
@@ -77,7 +70,7 @@ describe("削除ボタン", () => {
         createMockResponse({ isOk: true, status: HTTP_STATUS_NO_CONTENT })
       );
 
-      await clickDeleteButton(user);
+      await clickButtonByName(user, DELETE_BUTTON_ROLE_NAME);
 
       await waitFor(() => {
         // APIの呼び出しの確認
@@ -123,7 +116,7 @@ describe("削除ボタン", () => {
       const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       try {
         mockFetch.mockResolvedValueOnce(createMockResponse({ ...errorCase, isOk: false }));
-        await clickDeleteButton(user);
+        await clickButtonByName(user, DELETE_BUTTON_ROLE_NAME);
 
         expect(consoleErrorSpy).toHaveBeenCalledWith(
           "ブックマークの削除エラー:",

--- a/src/app/components/BookmarkManager/keyword.add.test.tsx
+++ b/src/app/components/BookmarkManager/keyword.add.test.tsx
@@ -21,14 +21,14 @@ import {
   deselectBookmark,
   findBookmarkWithAtLeastNKeywords,
   setupBookmarkManagerForTest,
+  typeInTextbox,
 } from "../../test-utils/bookmarkTestUtils";
 import { Bookmark } from "../../types/Bookmark";
 
 const mockFetch = vi.fn();
 
 const addNewKeyword = async (user: UserEvent, keyword: string) => {
-  const keywordInput = screen.getByRole("textbox", { name: KEYWORD_ROLE_NAME });
-  await user.type(keywordInput, keyword);
+  await typeInTextbox(user, KEYWORD_ROLE_NAME, keyword);
   await clickButtonByName(user, ADD_BUTTON_ROLE_NAME);
 };
 

--- a/src/app/components/BookmarkManager/keyword.add.test.tsx
+++ b/src/app/components/BookmarkManager/keyword.add.test.tsx
@@ -16,6 +16,7 @@ import {
   assertBookmarkIsSelected,
   buildMockBookmarksWithKeywords,
   clickBookmark,
+  clickButtonByName,
   createMockResponse,
   deselectBookmark,
   findBookmarkWithAtLeastNKeywords,
@@ -27,9 +28,8 @@ const mockFetch = vi.fn();
 
 const addNewKeyword = async (user: UserEvent, keyword: string) => {
   const keywordInput = screen.getByRole("textbox", { name: KEYWORD_ROLE_NAME });
-  const addButton = screen.getByRole("button", { name: ADD_BUTTON_ROLE_NAME });
   await user.type(keywordInput, keyword);
-  await user.click(addButton);
+  await clickButtonByName(user, ADD_BUTTON_ROLE_NAME);
 };
 
 const expectTableRows = (expectRows: number) => {

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -19,6 +19,7 @@ import {
   assertBookmarkIsSelected,
   assertErrorMessage,
   clickBookmark,
+  clickButtonByName,
   createBookmark,
   createMockResponse,
   expectBookmarkFormValues,
@@ -31,14 +32,6 @@ import {
 import { Bookmark } from "../../types/Bookmark";
 
 const mockFetch = vi.fn();
-
-const clickUpdateButton = async (user: UserEvent) => {
-  const updateButton = screen.getByRole("button", {
-    name: UPDATE_BUTTON_ROLE_NAME,
-  });
-
-  await user.click(updateButton);
-};
 
 describe("タイトルの更新ボタン", () => {
   let user: UserEvent;
@@ -207,7 +200,7 @@ describe("タイトルの更新ボタン", () => {
       ])("エラーハンドリング: $description", async ({ errorCase }) => {
         mockFetch.mockResolvedValueOnce(createMockResponse({ ...errorCase, isOk: false }));
 
-        await clickUpdateButton(user);
+        await clickButtonByName(user, UPDATE_BUTTON_ROLE_NAME);
 
         expect(consoleErrorSpy).toHaveBeenCalledWith(
           "ブックマークの更新エラー:",

--- a/src/app/components/ErrorMessage.test.tsx
+++ b/src/app/components/ErrorMessage.test.tsx
@@ -2,10 +2,10 @@ import "@testing-library/jest-dom";
 
 import { beforeEach, describe, expect, it, vi } from "vitest"; // Vitestから必要なものをインポート
 
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 
-import { assertErrorMessage } from "../test-utils/bookmarkTestUtils";
+import { assertErrorMessage, clickButtonByName } from "../test-utils/bookmarkTestUtils";
 import { ErrorMessage } from "./ErrorMessage";
 
 describe("ErrorMessage", () => {
@@ -59,7 +59,7 @@ describe("ErrorMessage", () => {
         handleErrorClose={handleErrorClose}
       />
     );
-    await user.click(screen.getByRole("button", { name: "閉じる" }));
+    await clickButtonByName(user, "閉じる");
     expect(handleErrorClose).toHaveBeenCalledTimes(1);
   });
 

--- a/src/app/hooks/useErrorMessage.test.tsx
+++ b/src/app/hooks/useErrorMessage.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 
 import { useErrorMessage } from "./useErrorMessage";
+import { clickButtonByName } from "../test-utils/bookmarkTestUtils";
 
 describe("useErrorMessage", () => {
   let user: UserEvent;
@@ -37,7 +38,7 @@ describe("useErrorMessage", () => {
 
   it("should set error message and update textMessage", async () => {
     render(<TestComponent />);
-    await user.click(screen.getByRole("button", { name: "Set Error" }));
+    await clickButtonByName(user, "Set Error");
 
     // useEffect の更新を待つ
     await waitFor(() => {
@@ -48,7 +49,7 @@ describe("useErrorMessage", () => {
 
   it("should set loading message and update textMessage", async () => {
     render(<TestComponent />);
-    await user.click(screen.getByRole("button", { name: "Set Loading" }));
+    await clickButtonByName(user, "Set Loading");
 
     // useEffect の更新を待つ
     await waitFor(() => {
@@ -59,13 +60,15 @@ describe("useErrorMessage", () => {
 
   it("should prioritize error message over loading message", async () => {
     render(<TestComponent />);
-    await user.click(screen.getByRole("button", { name: "Set Loading" }));
 
+    await clickButtonByName(user, "Set Loading");
+
+    // useEffect の更新を待つ
     await waitFor(() => {
       expect(screen.getByTestId("text-message")).toHaveTextContent("Test Loading");
     });
 
-    await user.click(screen.getByRole("button", { name: "Set Error" }));
+    await clickButtonByName(user, "Set Error");
 
     await waitFor(() => {
       expect(screen.getByTestId("text-message")).toHaveTextContent("Test Error");
@@ -75,13 +78,14 @@ describe("useErrorMessage", () => {
 
   it("should clear textMessage when handleErrorClose is called", async () => {
     render(<TestComponent />);
-    await user.click(screen.getByRole("button", { name: "Set Error" }));
+    await clickButtonByName(user, "Set Error");
 
+    // useEffect の更新を待つ
     await waitFor(() => {
       expect(screen.getByTestId("text-message")).toHaveTextContent("Test Error");
     });
 
-    await user.click(screen.getByRole("button", { name: "Close Error" }));
+    await clickButtonByName(user, "Close Error");
 
     expect(screen.getByTestId("text-message")).toHaveTextContent("");
     expect(screen.getByTestId("error-state")).toHaveTextContent("false"); // handleErrorCloseはerrorMessageの状態を変更しない

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -222,7 +222,7 @@ export const createMockResponse = ({
   return response;
 };
 
-const typeInTextbox = async (user: UserEvent, name: string, value: string) => {
+export const typeInTextbox = async (user: UserEvent, name: string, value: string) => {
   const textbox = screen.getByRole("textbox", { name });
   await user.clear(textbox);
   if (value.length > 0) {

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -230,6 +230,11 @@ const typeInTextbox = async (user: UserEvent, name: string, value: string) => {
   }
 };
 
+export const clickButtonByName = async (user: UserEvent, name: string) => {
+  const button = screen.getByRole("button", { name });
+  await user.click(button);
+};
+
 export const setBookmarkFormValuesAndClickButton = async (
   user: UserEvent,
   values: {
@@ -245,7 +250,7 @@ export const setBookmarkFormValuesAndClickButton = async (
     await typeInTextbox(user, TITLE_ROLE_NAME, values.title);
   }
   if (buttonName !== undefined) {
-    await user.click(screen.getByRole("button", { name: buttonName }));
+    await clickButtonByName(user, buttonName);
   }
 };
 


### PR DESCRIPTION
## 概要
テストコード全体で利用されているボタンクリックのヘルパー関数を、汎用的な clickButtonByName に統一しました。 これにより、各テストファイルに存在していた同様の目的を持つ関数（clickDeleteButton, addButton, clickUpdateButton など）を削除し、コードの重複を削減しました。

## 変更の目的
- 保守性の向上: ボタンクリックのロジックを一箇所に集約することで、将来的な仕様変更への対応が容易になります。
- 可読性の向上: 各テストコードがよりシンプルになり、何を行っているかが分かりやすくなりました。
- コードの削減: 重複したコードを削除し、テストスイート全体をスリム化しました。

## 主な変更点
- [src/app/test-utils/bookmarkTestUtils.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/test-utils/bookmarkTestUtils.tsx)
  - 汎用的な clickButtonByName ヘルパー関数を追加しました。
- 以下のテストファイルで、個別のクリックヘルパーを clickButtonByName に置き換えました。
  - [delete.test.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/components/BookmarkManager/delete.test.tsx)
  - [keyword.add.test.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/components/BookmarkManager/keyword.add.test.tsx)
  - [update.test.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/components/BookmarkManager/update.test.tsx)
  - [ErrorMessage.test.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/components/ErrorMessage.test.tsx)
  - [useErrorMessage.test.tsx](code-assist-path:/home/user1/projects/linkpage/src/app/hooks/useErrorMessage.test.tsx)