### PR TITLE
test(api): getErrorMessageユーティリティのテストカバレッジを向上

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "1.14.1",
+      "version": "1.14.2",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/utils/ApiUtils.test.ts
+++ b/src/app/api/utils/ApiUtils.test.ts
@@ -126,17 +126,27 @@ describe("ApiUtils", () => {
 
   describe("getErrorMessage", () => {
     describe("error が ApiError インスタンスの場合", () => {
-      it("isLog が true の場合、toString() の結果を返す", () => {
-        const apiError = new ApiError("API error", 400);
-        expect(getErrorMessage(apiError, "fallback", true)).toBe(apiError.toString());
-      });
-      it("isLog が false の場合、message プロパティを返す", () => {
-        const apiError = new ApiError("API error", 400);
-        expect(getErrorMessage(apiError, "fallback", false)).toBe("API error");
-      });
-      it("isLog が未指定の場合、toString() の結果を返す", () => {
-        const apiError = new ApiError("API error", 400);
-        expect(getErrorMessage(apiError, "fallback")).toBe(apiError.toString());
+      const apiError = new ApiError("API error", 400);
+      const testCases = [
+        {
+          description: "isLog が true の場合、toString() の結果を返す",
+          isLog: true,
+          expected: apiError.toString(),
+        },
+        {
+          description: "isLog が false の場合、message プロパティを返す",
+          isLog: false,
+          expected: "API error",
+        },
+        {
+          description: "isLog が未指定の場合、toString() の結果を返す",
+          isLog: undefined,
+          expected: apiError.toString(),
+        },
+      ];
+
+      it.each(testCases)("$description", ({ isLog, expected }) => {
+        expect(getErrorMessage(apiError, "fallback", isLog)).toBe(expected);
       });
     });
 

--- a/src/app/api/utils/ApiUtils.test.ts
+++ b/src/app/api/utils/ApiUtils.test.ts
@@ -10,6 +10,7 @@ import {
   ERROR_MESSAGE_PARSE_JSON,
   ERROR_MESSAGE_READ_RESPONSE_BODY,
   ERROR_UNEXPECTED_RESPONSE_FORMAT,
+  getErrorMessage,
   parseApiError,
 } from "./ApiUtils";
 import { createErrorResponse } from "./response";
@@ -121,5 +122,60 @@ describe("ApiUtils", () => {
       );
       expect(error.cause).toBe(readError);
     });
+  });
+
+  describe("getErrorMessage", () => {
+    it("error が ApiError インスタンスで isLog が true の場合、toString() の結果を返す", () => {
+      const apiError = new ApiError("API error", 400);
+      expect(getErrorMessage(apiError, "fallback", true)).toBe(apiError.toString());
+    });
+
+    it("error が ApiError インスタンスで isLog が false の場合、message プロパティを返す", () => {
+      const apiError = new ApiError("API error", 400);
+      expect(getErrorMessage(apiError, "fallback", false)).toBe("API error");
+    });
+
+    it("error が通常の Error インスタンスの場合、message プロパティを返す", () => {
+      const error = new Error("Normal error");
+      expect(getErrorMessage(error)).toBe("Normal error");
+    });
+
+    it("error が Error インスタンスだが message プロパティが空の場合、フォールバックメッセージを返す", () => {
+      const errorWithEmptyMessage = new Error("");
+      const errorWithWhitespaceMessage = new Error("   ");
+      const fallbackMessage = "Fallback message";
+      expect(getErrorMessage(errorWithEmptyMessage, fallbackMessage)).toBe(fallbackMessage);
+      expect(getErrorMessage(errorWithWhitespaceMessage, fallbackMessage)).toBe(fallbackMessage);
+    });
+
+    it.each([
+      { description: "null", error: null },
+      { description: "undefined", error: undefined },
+      { description: "文字列", error: "some string" },
+      { description: "数値", error: 123 },
+      { description: "オブジェクト", error: {} },
+    ])("error が $description で fallbackMessage が指定されている場合、それを返す", ({ error }) => {
+      const fallbackMessage = "Fallback message";
+      expect(getErrorMessage(error, fallbackMessage)).toBe(fallbackMessage);
+    });
+
+    it("error が null または undefined でフォールバックもない場合、デフォルトメッセージを返す", () => {
+      const defaultMessage = "不明なエラーが発生しました。";
+      expect(getErrorMessage(null)).toBe(defaultMessage);
+      expect(getErrorMessage(undefined)).toBe(defaultMessage);
+    });
+
+    it.each([
+      { description: "Errorインスタンスだがメッセージが空", error: new Error("") },
+      { description: "文字列", error: "some string" },
+      { description: "数値", error: 123 },
+      { description: "オブジェクト", error: {} },
+    ])(
+      "error ($description) からメッセージを抽出できず、フォールバックもない場合、デフォルトメッセージを返す",
+      ({ error }) => {
+        const defaultMessage = "不明なエラーが発生しました。";
+        expect(getErrorMessage(error)).toBe(defaultMessage);
+      }
+    );
   });
 });

--- a/src/app/api/utils/ApiUtils.test.ts
+++ b/src/app/api/utils/ApiUtils.test.ts
@@ -127,33 +127,25 @@ describe("ApiUtils", () => {
 
   describe("getErrorMessage", () => {
     describe("error が ApiError インスタンスの場合", () => {
-      const apiError = new ApiError("API error", 400);
-      const testCases = [
-        {
-          description: "isLog が true の場合、toString() の結果を返す",
-          isLog: true,
-          expected: apiError.toString(),
-        },
-        {
-          description: "isLog が false の場合、message プロパティを返す",
-          isLog: false,
-          expected: "API error",
-        },
-        {
-          description: "isLog が未指定の場合、toString() の結果を返す",
-          isLog: undefined,
-          expected: apiError.toString(),
-        },
-      ];
+      const apiErrorMessage = "API error";
+      const apiError = new ApiError(apiErrorMessage, 400);
 
-      it.each(testCases)("$description", ({ isLog, expected }) => {
-        expect(getErrorMessage(apiError, "fallback", isLog)).toBe(expected);
+      it.each([
+        { isLog: true, description: "true" },
+        { isLog: undefined, description: "未指定(デフォルト)" },
+      ])("isLog が $description の場合、toString() の結果を返す", ({ isLog }) => {
+        expect(getErrorMessage(apiError, "fallback", isLog)).toBe(apiError.toString());
+      });
+
+      it("isLog が false の場合、message プロパティを返す", () => {
+        expect(getErrorMessage(apiError, "fallback", false)).toBe(apiErrorMessage);
       });
     });
 
     it("error が通常の Error インスタンスの場合、message プロパティを返す", () => {
-      const error = new Error("Normal error");
-      expect(getErrorMessage(error)).toBe("Normal error");
+      const normalErrorMessage = "Normal error";
+      const normalError = new Error(normalErrorMessage);
+      expect(getErrorMessage(normalError)).toBe(normalErrorMessage);
     });
 
     const fallbackMessage = "Fallback message";

--- a/src/app/api/utils/ApiUtils.test.ts
+++ b/src/app/api/utils/ApiUtils.test.ts
@@ -140,42 +140,35 @@ describe("ApiUtils", () => {
       expect(getErrorMessage(error)).toBe("Normal error");
     });
 
-    it("error が Error インスタンスだが message プロパティが空の場合、フォールバックメッセージを返す", () => {
-      const errorWithEmptyMessage = new Error("");
-      const errorWithWhitespaceMessage = new Error("   ");
-      const fallbackMessage = "Fallback message";
-      expect(getErrorMessage(errorWithEmptyMessage, fallbackMessage)).toBe(fallbackMessage);
-      expect(getErrorMessage(errorWithWhitespaceMessage, fallbackMessage)).toBe(fallbackMessage);
+    const fallbackMessage = "Fallback message";
+    const defaultMessage = "不明なエラーが発生しました。";
+
+    describe("フォールバックメッセージが指定されている場合", () => {
+      it.each([
+        { description: "null", error: null },
+        { description: "undefined", error: undefined },
+        { description: "文字列", error: "some string" },
+        { description: "数値", error: 123 },
+        { description: "オブジェクト", error: {} },
+        { description: "Errorインスタンス(メッセージ空)", error: new Error("") },
+        { description: "Errorインスタンス(メッセージ空白)", error: new Error("   ") },
+      ])("error が $description の場合、フォールバックメッセージを返す", ({ error }) => {
+        expect(getErrorMessage(error, fallbackMessage)).toBe(fallbackMessage);
+      });
     });
 
-    it.each([
-      { description: "null", error: null },
-      { description: "undefined", error: undefined },
-      { description: "文字列", error: "some string" },
-      { description: "数値", error: 123 },
-      { description: "オブジェクト", error: {} },
-    ])("error が $description で fallbackMessage が指定されている場合、それを返す", ({ error }) => {
-      const fallbackMessage = "Fallback message";
-      expect(getErrorMessage(error, fallbackMessage)).toBe(fallbackMessage);
-    });
-
-    it("error が null または undefined でフォールバックもない場合、デフォルトメッセージを返す", () => {
-      const defaultMessage = "不明なエラーが発生しました。";
-      expect(getErrorMessage(null)).toBe(defaultMessage);
-      expect(getErrorMessage(undefined)).toBe(defaultMessage);
-    });
-
-    it.each([
-      { description: "Errorインスタンスだがメッセージが空", error: new Error("") },
-      { description: "文字列", error: "some string" },
-      { description: "数値", error: 123 },
-      { description: "オブジェクト", error: {} },
-    ])(
-      "error ($description) からメッセージを抽出できず、フォールバックもない場合、デフォルトメッセージを返す",
-      ({ error }) => {
-        const defaultMessage = "不明なエラーが発生しました。";
+    describe("フォールバックメッセージが指定されていない場合", () => {
+      it.each([
+        { description: "null", error: null },
+        { description: "undefined", error: undefined },
+        { description: "文字列", error: "some string" },
+        { description: "数値", error: 123 },
+        { description: "オブジェクト", error: {} },
+        { description: "Errorインスタンス(メッセージ空)", error: new Error("") },
+        { description: "Errorインスタンス(メッセージ空白)", error: new Error("   ") },
+      ])("error が $description の場合、デフォルトメッセージを返す", ({ error }) => {
         expect(getErrorMessage(error)).toBe(defaultMessage);
-      }
-    );
+      });
+    });
   });
 });

--- a/src/app/api/utils/ApiUtils.test.ts
+++ b/src/app/api/utils/ApiUtils.test.ts
@@ -10,6 +10,7 @@ import {
   ERROR_MESSAGE_PARSE_JSON,
   ERROR_MESSAGE_READ_RESPONSE_BODY,
   ERROR_UNEXPECTED_RESPONSE_FORMAT,
+  ERROR_UNKNOWN,
   getErrorMessage,
   parseApiError,
 } from "./ApiUtils";
@@ -156,7 +157,7 @@ describe("ApiUtils", () => {
     });
 
     const fallbackMessage = "Fallback message";
-    const defaultMessage = "不明なエラーが発生しました。";
+    const defaultMessage = ERROR_UNKNOWN;
 
     const fallbackTestCases = [
       { description: "null", error: null },

--- a/src/app/api/utils/ApiUtils.test.ts
+++ b/src/app/api/utils/ApiUtils.test.ts
@@ -135,7 +135,7 @@ describe("ApiUtils", () => {
         { isLog: undefined, expected: apiError.toString(), description: "未指定(デフォルト)" },
         { isLog: false, expected: apiErrorMessage, description: "false" },
       ])("isLog が $description の場合、期待するメッセージを返す", ({ isLog, expected }) => {
-        expect(getErrorMessage(apiError, "fallback", isLog)).toBe(expected);
+        expect(getErrorMessage(apiError, "unused-fallback", isLog)).toBe(expected);
       });
     });
 

--- a/src/app/api/utils/ApiUtils.test.ts
+++ b/src/app/api/utils/ApiUtils.test.ts
@@ -125,14 +125,19 @@ describe("ApiUtils", () => {
   });
 
   describe("getErrorMessage", () => {
-    it("error が ApiError インスタンスで isLog が true の場合、toString() の結果を返す", () => {
-      const apiError = new ApiError("API error", 400);
-      expect(getErrorMessage(apiError, "fallback", true)).toBe(apiError.toString());
-    });
-
-    it("error が ApiError インスタンスで isLog が false の場合、message プロパティを返す", () => {
-      const apiError = new ApiError("API error", 400);
-      expect(getErrorMessage(apiError, "fallback", false)).toBe("API error");
+    describe("error が ApiError インスタンスの場合", () => {
+      it("isLog が true の場合、toString() の結果を返す", () => {
+        const apiError = new ApiError("API error", 400);
+        expect(getErrorMessage(apiError, "fallback", true)).toBe(apiError.toString());
+      });
+      it("isLog が false の場合、message プロパティを返す", () => {
+        const apiError = new ApiError("API error", 400);
+        expect(getErrorMessage(apiError, "fallback", false)).toBe("API error");
+      });
+      it("isLog が未指定の場合、toString() の結果を返す", () => {
+        const apiError = new ApiError("API error", 400);
+        expect(getErrorMessage(apiError, "fallback")).toBe(apiError.toString());
+      });
     });
 
     it("error が通常の Error インスタンスの場合、message プロパティを返す", () => {

--- a/src/app/api/utils/ApiUtils.test.ts
+++ b/src/app/api/utils/ApiUtils.test.ts
@@ -131,14 +131,11 @@ describe("ApiUtils", () => {
       const apiError = new ApiError(apiErrorMessage, 400);
 
       it.each([
-        { isLog: true, description: "true" },
-        { isLog: undefined, description: "未指定(デフォルト)" },
-      ])("isLog が $description の場合、toString() の結果を返す", ({ isLog }) => {
-        expect(getErrorMessage(apiError, "fallback", isLog)).toBe(apiError.toString());
-      });
-
-      it("isLog が false の場合、message プロパティを返す", () => {
-        expect(getErrorMessage(apiError, "fallback", false)).toBe(apiErrorMessage);
+        { isLog: true, expected: apiError.toString(), description: "true" },
+        { isLog: undefined, expected: apiError.toString(), description: "未指定(デフォルト)" },
+        { isLog: false, expected: apiErrorMessage, description: "false" },
+      ])("isLog が $description の場合、期待するメッセージを返す", ({ isLog, expected }) => {
+        expect(getErrorMessage(apiError, "fallback", isLog)).toBe(expected);
       });
     });
 

--- a/src/app/api/utils/ApiUtils.test.ts
+++ b/src/app/api/utils/ApiUtils.test.ts
@@ -168,22 +168,28 @@ describe("ApiUtils", () => {
       { description: "Errorインスタンス(メッセージ空白)", error: new Error("   ") },
     ];
 
-    describe("フォールバックメッセージが指定されている場合", () => {
-      it.each(fallbackTestCases)(
-        "error が $description の場合、フォールバックメッセージを返す",
-        ({ error }) => {
-          expect(getErrorMessage(error, fallbackMessage)).toBe(fallbackMessage);
-        }
-      );
-    });
+    describe("フォールバック動作のテスト", () => {
+      const fallbackScenarios = [
+        {
+          description: "フォールバックメッセージが指定されている場合",
+          fallback: fallbackMessage,
+          expected: fallbackMessage,
+        },
+        {
+          description: "フォールバックメッセージが指定されていない場合",
+          fallback: undefined,
+          expected: defaultMessage,
+        },
+      ];
 
-    describe("フォールバックメッセージが指定されていない場合", () => {
-      it.each(fallbackTestCases)(
-        "error が $description の場合、デフォルトメッセージを返す",
-        ({ error }) => {
-          expect(getErrorMessage(error)).toBe(defaultMessage);
-        }
-      );
+      describe.each(fallbackScenarios)("$description", ({ fallback, expected }) => {
+        it.each(fallbackTestCases)(
+          "error が $description の場合、期待されるメッセージを返す",
+          ({ error }) => {
+            expect(getErrorMessage(error, fallback)).toBe(expected);
+          }
+        );
+      });
     });
   });
 });

--- a/src/app/api/utils/ApiUtils.test.ts
+++ b/src/app/api/utils/ApiUtils.test.ts
@@ -152,6 +152,7 @@ describe("ApiUtils", () => {
       { description: "null", error: null },
       { description: "undefined", error: undefined },
       { description: "文字列", error: "some string" },
+      { description: "空文字列", error: "" },
       { description: "数値", error: 123 },
       { description: "オブジェクト", error: {} },
       { description: "Errorインスタンス(メッセージ空)", error: new Error("") },

--- a/src/app/api/utils/ApiUtils.test.ts
+++ b/src/app/api/utils/ApiUtils.test.ts
@@ -148,32 +148,32 @@ describe("ApiUtils", () => {
     const fallbackMessage = "Fallback message";
     const defaultMessage = "不明なエラーが発生しました。";
 
+    const fallbackTestCases = [
+      { description: "null", error: null },
+      { description: "undefined", error: undefined },
+      { description: "文字列", error: "some string" },
+      { description: "数値", error: 123 },
+      { description: "オブジェクト", error: {} },
+      { description: "Errorインスタンス(メッセージ空)", error: new Error("") },
+      { description: "Errorインスタンス(メッセージ空白)", error: new Error("   ") },
+    ];
+
     describe("フォールバックメッセージが指定されている場合", () => {
-      it.each([
-        { description: "null", error: null },
-        { description: "undefined", error: undefined },
-        { description: "文字列", error: "some string" },
-        { description: "数値", error: 123 },
-        { description: "オブジェクト", error: {} },
-        { description: "Errorインスタンス(メッセージ空)", error: new Error("") },
-        { description: "Errorインスタンス(メッセージ空白)", error: new Error("   ") },
-      ])("error が $description の場合、フォールバックメッセージを返す", ({ error }) => {
-        expect(getErrorMessage(error, fallbackMessage)).toBe(fallbackMessage);
-      });
+      it.each(fallbackTestCases)(
+        "error が $description の場合、フォールバックメッセージを返す",
+        ({ error }) => {
+          expect(getErrorMessage(error, fallbackMessage)).toBe(fallbackMessage);
+        }
+      );
     });
 
     describe("フォールバックメッセージが指定されていない場合", () => {
-      it.each([
-        { description: "null", error: null },
-        { description: "undefined", error: undefined },
-        { description: "文字列", error: "some string" },
-        { description: "数値", error: 123 },
-        { description: "オブジェクト", error: {} },
-        { description: "Errorインスタンス(メッセージ空)", error: new Error("") },
-        { description: "Errorインスタンス(メッセージ空白)", error: new Error("   ") },
-      ])("error が $description の場合、デフォルトメッセージを返す", ({ error }) => {
-        expect(getErrorMessage(error)).toBe(defaultMessage);
-      });
+      it.each(fallbackTestCases)(
+        "error が $description の場合、デフォルトメッセージを返す",
+        ({ error }) => {
+          expect(getErrorMessage(error)).toBe(defaultMessage);
+        }
+      );
     });
   });
 });

--- a/src/app/api/utils/ApiUtils.ts
+++ b/src/app/api/utils/ApiUtils.ts
@@ -9,6 +9,8 @@ export const ERROR_MESSAGE_PARSE_JSON =
 export const ERROR_UNEXPECTED_RESPONSE_FORMAT =
   "APIから予期せぬ形式のエラーレスポンスを受け取りました。";
 export const ERROR_MESSAGE_READ_RESPONSE_BODY = `APIエラーレスポンスのボディ読み取りに失敗しました。`;
+export const ERROR_UNKNOWN = "不明なエラーが発生しました。";
+
 /**
  * APIエラーを表すカスタムエラークラス。
  * @param message - エラーメッセージ（フォーマット前）
@@ -165,5 +167,5 @@ export const getErrorMessage = (
   }
 
   // 最終的なフォールバック
-  return "不明なエラーが発生しました。";
+  return ERROR_UNKNOWN;
 };


### PR DESCRIPTION
## 概要

`getErrorMessage` ユーティリティ関数のテストカバレッジを向上させるための変更です。
既存のテストではカバーしきれていなかったエッジケースを追加し、関数の堅牢性を高めました。

## 変更内容

このプルリクエストでは、`getErrorMessage` が様々な種類のエラーオブジェクトや入力値に対して期待通りに動作することを保証するために、以下のテストケースを追加しました。

- `ApiError` インスタンスを `isLog` フラグの有無でテストするケース
- メッセージが空文字列や空白のみで構成される `Error` インスタンスの挙動を検証するテスト
- `null`、`undefined`、その他のプリミティブ型が入力された場合のフォールバック動作を確認するテスト
- フォールバックメッセージが指定されていない場合に、デフォルトのメッセージが返却されることを検証するテスト

## 影響範囲

この変更はテストコードのみに限定されており、アプリケーションのランタイム動作には影響ありません。

fixes: #295 