### PR TITLE
refactor(test): キーワードAPIのテストコードをリファクタリング

### DIFF
--- a/src/app/api/keywords/[keyword_id]/delete.test.ts
+++ b/src/app/api/keywords/[keyword_id]/delete.test.ts
@@ -58,7 +58,7 @@ describe("キーワードDELETE APIのテスト", () => {
     });
 
     afterEach(() => {
-      consoleErrorSpy.mockRestore();
+      vi.restoreAllMocks();
     });
 
     const setupErrorCases = [
@@ -89,6 +89,18 @@ describe("キーワードDELETE APIのテスト", () => {
         logMessage: "Invalid ID provided: abc. It must be a positive integer.",
         setup: undefined,
       },
+      {
+        description: "DBエラーが発生した場合",
+        keywordId: "1",
+        statusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        errorMessage: "サーバー内部でエラーが発生しました。",
+        logMessage: "Internal Server Error: DB Error",
+        setup: () => {
+          vi.mocked(getDb).mockImplementation(() => {
+            throw new Error("DB Error");
+          });
+        },
+      },
     ];
 
     it.each(setupErrorCases)(
@@ -103,25 +115,5 @@ describe("キーワードDELETE APIのテスト", () => {
         expect(consoleErrorSpy).toHaveBeenCalledWith(logMessage);
       }
     );
-
-    // DBエラーのテストケースを分離する
-    it("DBエラーが発生した場合に500エラーが返る", async () => {
-      const getDbSpy = vi.mocked(getDb).mockImplementation(() => {
-        throw new Error("DB error");
-      });
-
-      try {
-        const [req, ctx] = createDeleteRequest("1");
-        const response = await DELETE(req, ctx);
-        await assertErrorResponse(
-          response,
-          HTTP_STATUS_INTERNAL_SERVER_ERROR,
-          "サーバー内部でエラーが発生しました。"
-        );
-        expect(consoleErrorSpy).toHaveBeenCalledWith("Internal Server Error: DB error");
-      } finally {
-        getDbSpy.mockRestore();
-      }
-    });
   });
 });

--- a/src/app/api/keywords/[keyword_id]/delete.test.ts
+++ b/src/app/api/keywords/[keyword_id]/delete.test.ts
@@ -74,18 +74,6 @@ describe("キーワードDELETE APIのテスト", () => {
         },
       },
       {
-        description: "DBエラーが発生した場合",
-        keywordId: "1",
-        statusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
-        errorMessage: "サーバー内部でエラーが発生しました。",
-        logMessage: "Internal Server Error: DB error",
-        setup: async () => {
-          vi.mocked(getDb).mockImplementation(() => {
-            throw new Error("DB error");
-          });
-        },
-      },
-      {
         description: "存在しないIDを指定した場合",
         keywordId: "9999",
         statusCode: HTTP_STATUS_NOT_FOUND,
@@ -115,5 +103,25 @@ describe("キーワードDELETE APIのテスト", () => {
         expect(consoleErrorSpy).toHaveBeenCalledWith(logMessage);
       }
     );
+
+    // DBエラーのテストケースを分離する
+    it("DBエラーが発生した場合に500エラーが返る", async () => {
+      const getDbSpy = vi.mocked(getDb).mockImplementation(() => {
+        throw new Error("DB error");
+      });
+
+      try {
+        const [req, ctx] = createDeleteRequest("1");
+        const response = await DELETE(req, ctx);
+        await assertErrorResponse(
+          response,
+          HTTP_STATUS_INTERNAL_SERVER_ERROR,
+          "サーバー内部でエラーが発生しました。"
+        );
+        expect(consoleErrorSpy).toHaveBeenCalledWith("Internal Server Error: DB error");
+      } finally {
+        getDbSpy.mockRestore();
+      }
+    });
   });
 });

--- a/src/app/api/keywords/[keyword_id]/delete.test.ts
+++ b/src/app/api/keywords/[keyword_id]/delete.test.ts
@@ -68,8 +68,8 @@ describe("キーワードDELETE APIのテスト", () => {
         statusCode: HTTP_STATUS_NOT_FOUND,
         errorMessage: "指定されたキーワードが見つかりません。",
         logMessage: "Keyword with id: 1 not found.",
-        setup: async (id: string) => {
-          const [req, ctx] = createDeleteRequest(id);
+        setup: async (keywordId: string) => {
+          const [req, ctx] = createDeleteRequest(keywordId);
           await DELETE(req, ctx); // 1回目の削除 (keywordId "1" を使用)
         },
       },
@@ -95,7 +95,7 @@ describe("キーワードDELETE APIのテスト", () => {
       `$descriptionに$statusCodeでエラーメッセージが返る`,
       async ({ setup, keywordId, statusCode, errorMessage, logMessage }) => {
         if (setup) {
-          await setup(keywordId); // ここで keywordId を渡すように変更する
+          await setup(keywordId);
         }
         const [req, ctx] = createDeleteRequest(keywordId);
         const response = await DELETE(req, ctx);

--- a/src/app/api/keywords/[keyword_id]/delete.test.ts
+++ b/src/app/api/keywords/[keyword_id]/delete.test.ts
@@ -1,5 +1,5 @@
 import ActualDatabase from "better-sqlite3";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import {
   HTTP_STATUS_BAD_REQUEST,
@@ -15,8 +15,6 @@ import { DELETE } from "./route";
 
 vi.mock("../../bookmarks/database");
 
-let inMemoryDbInstance: ActualDatabase.Database;
-
 const createDeleteRequest = (
   keyword_id: string
 ): [Request, { params: Promise<{ keyword_id: string }> }] => {
@@ -27,6 +25,8 @@ const createDeleteRequest = (
 };
 
 describe("キーワードDELETE APIのテスト", () => {
+  let inMemoryDbInstance: ActualDatabase.Database;
+
   beforeEach(() => {
     vi.resetAllMocks();
     inMemoryDbInstance = setupInMemoryDb();
@@ -40,48 +40,80 @@ describe("キーワードDELETE APIのテスト", () => {
   });
 
   it("DELETE: 正常にキーワードが削除できる", async () => {
-    const [req, ctx] = createDeleteRequest("1");
+    const keywordId = "1";
+    const [req, ctx] = createDeleteRequest(keywordId);
     const response = await DELETE(req, ctx);
     expect(response.status).toBe(HTTP_STATUS_NO_CONTENT);
-    // 削除後にもう一度削除を試みると404になることを確認
-    const response2 = await DELETE(req, ctx);
-    await assertErrorResponse(
-      response2,
-      HTTP_STATUS_NOT_FOUND,
-      "指定されたキーワードが見つかりません。"
-    );
+
+    // データベースから削除されたことを確認
+    const stmt = inMemoryDbInstance.prepare("SELECT keyword_id FROM keywords WHERE keyword_id = ?");
+    const dbData = stmt.get(keywordId);
+    expect(dbData).toBeUndefined();
   });
 
-  it("DELETE: 存在しないIDの場合404を返す", async () => {
-    const [req, ctx] = createDeleteRequest("9999");
-    const response = await DELETE(req, ctx);
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_NOT_FOUND,
-      "指定されたキーワードが見つかりません。"
-    );
-  });
-
-  it("DELETE: 不正なIDの場合400を返す", async () => {
-    const [req, ctx] = createDeleteRequest("abc");
-    const response = await DELETE(req, ctx);
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_BAD_REQUEST,
-      "IDは正の整数である必要があります。"
-    );
-  });
-
-  it("DELETE: DBエラー時は500を返す", async () => {
-    vi.mocked(getDb).mockImplementation(() => {
-      throw new Error("DB error");
+  describe("エラーログが出力される場合のテスト", () => {
+    let consoleErrorSpy: MockInstance;
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
-    const [req, ctx] = createDeleteRequest("1");
-    const response = await DELETE(req, ctx);
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    const setupErrorCases = [
+      {
+        description: "削除済みのIDで再度削除しようした場合",
+        keywordId: "1",
+        statusCode: HTTP_STATUS_NOT_FOUND,
+        errorMessage: "指定されたキーワードが見つかりません。",
+        logMessage: "Keyword with id: 1 not found.",
+        setup: async (id: string) => {
+          const [req, ctx] = createDeleteRequest(id);
+          await DELETE(req, ctx); // 1回目の削除 (keywordId "1" を使用)
+        },
+      },
+      {
+        description: "DBエラーが発生した場合",
+        keywordId: "1",
+        statusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        errorMessage: "サーバー内部でエラーが発生しました。",
+        logMessage: "Internal Server Error: DB error",
+        setup: async () => {
+          vi.mocked(getDb).mockImplementation(() => {
+            throw new Error("DB error");
+          });
+        },
+      },
+      {
+        description: "存在しないIDを指定した場合",
+        keywordId: "9999",
+        statusCode: HTTP_STATUS_NOT_FOUND,
+        errorMessage: "指定されたキーワードが見つかりません。",
+        logMessage: "Keyword with id: 9999 not found.",
+        setup: undefined,
+      },
+      {
+        description: "不正なIDを指定した場合",
+        keywordId: "abc",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        errorMessage: "IDは正の整数である必要があります。",
+        logMessage: "Invalid ID provided: abc. It must be a positive integer.",
+        setup: undefined,
+      },
+    ];
+
+    it.each(setupErrorCases)(
+      `$descriptionに$statusCodeでエラーメッセージが返る`,
+      async ({ setup, keywordId, statusCode, errorMessage, logMessage }) => {
+        if (setup) {
+          await setup(keywordId); // ここで keywordId を渡すように変更する
+        }
+        const [req, ctx] = createDeleteRequest(keywordId);
+        const response = await DELETE(req, ctx);
+        await assertErrorResponse(response, statusCode, errorMessage);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(logMessage);
+      }
     );
   });
 });

--- a/src/app/api/keywords/get.test.ts
+++ b/src/app/api/keywords/get.test.ts
@@ -1,5 +1,5 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import { HTTP_STATUS_INTERNAL_SERVER_ERROR, HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../test-utils/assertions";
@@ -36,34 +36,53 @@ describe("キーワードGET APIのテスト", () => {
     expect(json).toEqual(mockKeywords);
   });
 
-  it("GET: データベースエラー時に500エラーを返す", async () => {
-    const dbError = new Error("Database connection failed");
-    vi.mocked(getDb).mockImplementation(() => {
-      throw dbError;
+  describe("GET: エラーログが出力される場合のテスト", () => {
+    let consoleErrorSpy: MockInstance;
+
+    beforeEach(() => {
+      // console.errorをスパイして、エラー出力がされるか確認
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    const response = await GET();
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
-    );
-  });
-
-  it("GET: クエリエラー時に500エラーを返す", async () => {
-    const queryError = new Error("Failed to execute query");
-    // prepareメソッドをモックしてクエリエラーを発生させる
-    const prepareSpy = vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
-      throw queryError;
+    afterEach(() => {
+      vi.restoreAllMocks();
     });
 
-    const response = await GET();
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
-    );
+    const errorTestCases = [
+      {
+        description: "データベースエラー時に500エラーを返す",
+        setup: () => {
+          const errorMessage = "Database connection failed";
+          // getDbをモックして、データベースエラーを発生させる
+          vi.mocked(getDb).mockImplementation(() => {
+            throw new Error(errorMessage);
+          });
+          return errorMessage;
+        },
+      },
+      {
+        description: "クエリエラー時に500エラーを返す",
+        setup: () => {
+          const errorMessage = "Failed to execute query";
+          // prepareメソッドをモックしてクエリエラーを発生させる
+          vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
+            throw new Error(errorMessage);
+          });
+          return errorMessage;
+        },
+      },
+    ];
 
-    prepareSpy.mockRestore();
+    it.each(errorTestCases)("$description", async ({ setup }) => {
+      const errorMessage = setup();
+      const response = await GET();
+
+      await assertErrorResponse(
+        response,
+        HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        "サーバー内部でエラーが発生しました。"
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(`Internal Server Error: ${errorMessage}`);
+    });
   });
 });

--- a/src/app/api/keywords/post.test.ts
+++ b/src/app/api/keywords/post.test.ts
@@ -86,7 +86,7 @@ describe("キーワードAPIのテスト", () => {
       consoleErrorSpy.mockRestore();
     });
 
-    const emptyKeywordTestCases = [
+    const invalidRequestTestCases = [
       {
         description: "不正なJSONデータ(JSON.parseエラー)",
         statusCode: HTTP_STATUS_BAD_REQUEST,
@@ -112,8 +112,8 @@ describe("キーワードAPIのテスト", () => {
       },
     ];
 
-    it.each(emptyKeywordTestCases)(
-      `POST: キーワードが$descriptionの場合は$statusCodeを返す`,
+    it.each(invalidRequestTestCases)(
+      `キーワードが$descriptionの場合は$statusCodeを返す`,
       async ({ statusCode, body, errorMessage, logMessage }) => {
         const response = await POST(
           new Request(API_KEYWORDS_URL, {

--- a/src/app/api/keywords/post.test.ts
+++ b/src/app/api/keywords/post.test.ts
@@ -92,7 +92,7 @@ describe("キーワードAPIのテスト", () => {
         statusCode: HTTP_STATUS_BAD_REQUEST,
         body: "invalid json",
         errorMessage: "リクエストボディのJSONが不正です。",
-        logMessage: "Invalid JSON format: Unexpected token 'i', \"invalid json\" is not valid JSON",
+        logMessage: expect.stringContaining("Invalid JSON format: Unexpected token"),
       },
       {
         description: "不正なJSONデータ(null)",

--- a/src/app/api/keywords/post.test.ts
+++ b/src/app/api/keywords/post.test.ts
@@ -83,7 +83,7 @@ describe("キーワードAPIのテスト", () => {
     });
 
     afterEach(() => {
-      consoleErrorSpy.mockRestore();
+      vi.restoreAllMocks();
     });
 
     const invalidRequestTestCases = [
@@ -110,11 +110,26 @@ describe("キーワードAPIのテスト", () => {
         errorMessage: "指定されたキーワードは既に登録されています。",
         logMessage: 'Keyword with "キーワード1" already exists.',
       },
+      {
+        description: "データベースエラーが発生した場合",
+        statusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        body: JSON.stringify({ keyword_name: "テスト" }),
+        errorMessage: "サーバー内部でエラーが発生しました。",
+        logMessage: "Internal Server Error: Failed to execute query",
+        setup: () => {
+          vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
+            throw new Error("Failed to execute query");
+          });
+        },
+      },
     ];
 
     it.each(invalidRequestTestCases)(
       `キーワードが$descriptionの場合は$statusCodeを返す`,
-      async ({ statusCode, body, errorMessage, logMessage }) => {
+      async ({ statusCode, body, errorMessage, logMessage, setup }) => {
+        if (setup) {
+          setup();
+        }
         const response = await POST(
           new Request(API_KEYWORDS_URL, {
             method: "POST",
@@ -128,25 +143,5 @@ describe("キーワードAPIのテスト", () => {
         expect(consoleErrorSpy).toHaveBeenCalledWith(logMessage);
       }
     );
-
-    it("POST: データベースエラー時に500エラーを返す", async () => {
-      const queryError = new Error("Failed to execute query");
-      // prepareメソッドをモックしてクエリエラーを発生させる
-      const prepareSpy = vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
-        throw queryError;
-      });
-
-      const response = await POST(createPostRequest("テスト"));
-      await assertErrorResponse(
-        response,
-        HTTP_STATUS_INTERNAL_SERVER_ERROR,
-        "サーバー内部でエラーが発生しました。"
-      );
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "Internal Server Error: Failed to execute query"
-      );
-
-      prepareSpy.mockRestore();
-    });
   });
 });

--- a/src/app/api/keywords/post.test.ts
+++ b/src/app/api/keywords/post.test.ts
@@ -1,5 +1,5 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import {
   HTTP_STATUS_BAD_REQUEST,
@@ -74,64 +74,79 @@ describe("キーワードAPIのテスト", () => {
     await assertErrorResponse(response, HTTP_STATUS_BAD_REQUEST, "キーワードを指定してください。");
   });
 
-  it("POST: 不正なJSONデータ(JSON.parseエラー)の場合は400を返す", async () => {
-    const response = await POST(
-      new Request(API_KEYWORDS_URL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: "invalid json",
-      })
-    );
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_BAD_REQUEST,
-      "リクエストボディのJSONが不正です。"
-    );
-  });
+  describe("POST: エラーログが出力される場合のテスト", () => {
+    let consoleErrorSpy: MockInstance;
 
-  it("POST: 不正なJSONデータ(null)の場合は400を返す", async () => {
-    const response = await POST(
-      new Request(API_KEYWORDS_URL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(null),
-      })
-    );
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_BAD_REQUEST,
-      "リクエストボディのJSONが不正です。"
-    );
-  });
-
-  it("POST: 重複したキーワードを追加時に409 Conflictを返す", async () => {
-    const response = await POST(createPostRequest(mockKeywords[0].keyword_name));
-
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_CONFLICT,
-      "指定されたキーワードは既に登録されています。"
-    );
-  });
-
-  it("POST: データベースエラー時に500エラーを返す", async () => {
-    const queryError = new Error("Failed to execute query");
-    // prepareメソッドをモックしてクエリエラーを発生させる
-    const prepareSpy = vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
-      throw queryError;
+    beforeEach(() => {
+      // console.errorをスパイして、エラー出力がされるか確認
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    const response = await POST(createPostRequest("テスト"));
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    const emptyKeywordTestCases = [
+      {
+        description: "不正なJSONデータ(JSON.parseエラー)",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        body: "invalid json",
+        errorMessage: "リクエストボディのJSONが不正です。",
+        logMessage: "Invalid JSON format: Unexpected token 'i', \"invalid json\" is not valid JSON",
+      },
+      {
+        description: "不正なJSONデータ(null)",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        body: JSON.stringify(null),
+        errorMessage: "リクエストボディのJSONが不正です。",
+        logMessage: "Invalid JSON format: リクエストボディのJSONが不正です。",
+      },
+      {
+        description: "重複したキーワードを追加",
+        statusCode: HTTP_STATUS_CONFLICT,
+        body: JSON.stringify({
+          keyword_name: mockKeywords[0].keyword_name,
+        }),
+        errorMessage: "指定されたキーワードは既に登録されています。",
+        logMessage: 'Keyword with "キーワード1" already exists.',
+      },
+    ];
+
+    it.each(emptyKeywordTestCases)(
+      `POST: キーワードが$descriptionの場合は$statusCodeを返す`,
+      async ({ statusCode, body, errorMessage, logMessage }) => {
+        const response = await POST(
+          new Request(API_KEYWORDS_URL, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body,
+          })
+        );
+        await assertErrorResponse(response, statusCode, errorMessage);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(logMessage);
+      }
     );
 
-    prepareSpy.mockRestore();
+    it("POST: データベースエラー時に500エラーを返す", async () => {
+      const queryError = new Error("Failed to execute query");
+      // prepareメソッドをモックしてクエリエラーを発生させる
+      const prepareSpy = vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
+        throw queryError;
+      });
+
+      const response = await POST(createPostRequest("テスト"));
+      await assertErrorResponse(
+        response,
+        HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        "サーバー内部でエラーが発生しました。"
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Internal Server Error: Failed to execute query"
+      );
+
+      prepareSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
## 概要
キーワード関連API (/api/keywords) のテストコードをリファクタリングし、可読性と保守性を向上させます。 これは #301 から分割されたタスクです。

個別に記述されていた各APIエンドポイントのエラーハンドリングに関するテストケースを it.each を用いて共通化し、コードの重複を削減しました。

## 変更点
- テストの共通化:
  - GET /api/keywords, POST /api/keywords, DELETE /api/keywords/[keyword_id] の各エンドポイントにおける異常系テストを it.each を用いてパラメタライズドテストに統合しました。
- アサーションの強化:
  - 各エラーケースで console.error が期待通りに呼び出され、適切なエラーメッセージがログに出力されることを検証するアサーションを追加しました。
  - DELETE の正常系テストにおいて、API実行後にデータベースから該当データが削除されていることを直接確認するようにアサーションを改善しました。

## 関連Issue
- Closes #304