### PR TITLE
feat(api): APIエラーハンドリングの改善とテストコードのリファクタリング

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,13 @@ linkpage はリンクデータを SQLite のデータベースで管理します
 | [SQLite](https://www.sqlite.org/index.html)   | 3.37.2     |
 | [vitest](https://vitest.dev)                  | 3.2.3      |
 
+## 変更履歴
+
+### 2025/09/01
+
+- fix: 不正な JSON ボディに対するエラーメッセージを統一
+- feat: キーワード追加 API のリクエストボディ検証を強化し、より具体的なエラーメッセージを返すよう変更
+
 ## ライセンス
 
 このプロジェクトは[MIT ライセンス](LICENSE)の下で公開されています。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "better-sqlite3": "^11.9.1",
         "next": "15.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/bookmarks/[bookmark_id]/delete.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/delete.test.ts
@@ -1,5 +1,5 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import {
   HTTP_STATUS_BAD_REQUEST,
@@ -11,6 +11,7 @@ import { assertErrorResponse } from "../../../test-utils/assertions";
 import { GOOGLE_BOOKMARK, mockBookmarks } from "../../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../../test-utils/db-setup";
 import { API_BOOKMARKS_URL } from "../../utils/constants";
+import { ErrorTestCase } from "../../utils/types";
 import { getDb } from "../database";
 import { DELETE } from "./route";
 
@@ -85,50 +86,68 @@ describe("ブックマーク削除APIのテスト (オンメモリDB)", () => {
     expect(countAfter).toBe(mockBookmarks.length - 1);
   });
 
-  it("DELETE: 登録されていないブックマークIDを指定された場合は404を返す", async () => {
-    const nonExistentId = 99999; // 存在しないID
-    const [request, context] = createDeleteRequest(nonExistentId.toString());
-    const response = await DELETE(request, context);
+  describe("DELETE: エラーログが出力される場合のテスト", () => {
+    let consoleErrorSpy: MockInstance;
 
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_NOT_FOUND,
-      "指定されたブックマークがありません。"
-    );
-
-    // ブックマーク数が変わっていないことを確認
-    const count = (
-      inMemoryDbInstance.prepare("SELECT COUNT(*) as count FROM bookmarks").get() as {
-        count: number;
-      }
-    ).count;
-    expect(count).toBe(mockBookmarks.length);
-  });
-
-  it("DELETE: データベースエラーの場合は500エラーを返す", async () => {
-    vi.mocked(getDb).mockImplementation(() => {
-      throw new Error("DB error");
+    beforeEach(() => {
+      // console.errorをスパイして、エラー出力がされるか確認
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
-    const anyValidId = 1; // DBエラーのテストなので、IDは任意の値で問題ありません。
-    const [request, context] = createDeleteRequest(anyValidId.toString());
-    const response = await DELETE(request, context);
 
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
-    );
-  });
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
 
-  it("DELETE: 不正なIDの場合には400エラーを返す", async () => {
-    const nonExistentId = -1; // 不正なID
-    const [request, context] = createDeleteRequest(nonExistentId.toString());
-    const response = await DELETE(request, context);
+    const errorTestCases: ErrorTestCase<number | string>[] = [
+      {
+        description: "登録されていないIDの場合に404エラーを返す",
+        statusCode: HTTP_STATUS_NOT_FOUND,
+        errorMessage: "指定されたブックマークがありません。",
+        logMessage: `Bookmark with id: 99999 not found.`,
+        body: 99999,
+      },
+      {
+        description: "データベースエラー時に500エラーを返す",
+        statusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        errorMessage: "サーバー内部でエラーが発生しました。",
+        logMessage: "Internal Server Error: DB error",
+        body: 1,
+        setup: () => {
+          vi.mocked(getDb).mockImplementation(() => {
+            throw new Error("DB error");
+          });
+        },
+      },
+      {
+        description: "不正なIDの場合に400エラーを返す",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        errorMessage: "IDは正の整数である必要があります。",
+        logMessage: "Invalid ID provided: -1. It must be a positive integer.",
+        body: "-1",
+      },
+    ];
 
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_BAD_REQUEST,
-      "IDは正の整数である必要があります。"
+    it.each(errorTestCases)(
+      "$description",
+      async ({ setup, body, statusCode, errorMessage, logMessage }) => {
+        if (setup) {
+          setup();
+        }
+
+        const [request, context] = createDeleteRequest(body.toString());
+        const response = await DELETE(request, context);
+
+        await assertErrorResponse(response, statusCode, errorMessage);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(logMessage);
+
+        // ブックマーク数が変わっていないことを確認
+        const count = (
+          inMemoryDbInstance.prepare("SELECT COUNT(*) as count FROM bookmarks").get() as {
+            count: number;
+          }
+        ).count;
+        expect(count).toBe(mockBookmarks.length);
+      }
     );
   });
 });

--- a/src/app/api/bookmarks/[bookmark_id]/get.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/get.test.ts
@@ -1,5 +1,5 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import {
   HTTP_STATUS_BAD_REQUEST,
@@ -11,6 +11,7 @@ import { assertErrorResponse } from "../../../test-utils/assertions";
 import { expectEqualBookmark, GOOGLE_BOOKMARK } from "../../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../../test-utils/db-setup";
 import { API_BOOKMARKS_URL } from "../../utils/constants";
+import { ErrorTestCase } from "../../utils/types";
 import { getDb } from "../database";
 import { GET } from "./route";
 
@@ -20,11 +21,9 @@ let inMemoryDbInstance: ActualDatabase.Database;
 
 const createGetRequest = (
   bookmark_id: string
-  // ): [Request, { params: { id: string } }] => {
 ): [Request, { params: Promise<{ bookmark_id: string }> }] => {
   return [
     new Request(`${API_BOOKMARKS_URL}${bookmark_id}`, { method: "Get" }),
-    // { params: { id } },
     { params: Promise.resolve({ bookmark_id: bookmark_id.toString() }) },
   ];
 };
@@ -56,58 +55,72 @@ describe("ブックマークを1件取得するAPIのテスト", () => {
     expectEqualBookmark(json, targetBookmark);
   });
 
-  it("GET: 不正なIDの場合400エラーを返す", async () => {
-    const [request, context] = createGetRequest("abc");
-    const response = await GET(request, context);
+  describe("GET: エラーログが出力される場合のテスト", () => {
+    let consoleErrorSpy: MockInstance;
 
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_BAD_REQUEST,
-      "IDは正の整数である必要があります。"
-    );
-  });
-
-  it("GET: 存在しないIDの場合404エラーを返す", async () => {
-    const [request, context] = createGetRequest("100");
-    const response = await GET(request, context);
-
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_NOT_FOUND,
-      "指定されたブックマークがありません。"
-    );
-  });
-
-  it("GET: データベースエラー時に500エラーを返す", async () => {
-    const dbError = new Error("Database connection failed");
-    vi.mocked(getDb).mockImplementation(() => {
-      throw dbError;
+    beforeEach(() => {
+      // console.errorをスパイして、エラー出力がされるか確認
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    const [request, context] = createGetRequest("1");
-    const response = await GET(request, context);
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
-    );
-  });
-
-  it("GET: クエリエラー時に500エラーを返す", async () => {
-    const queryError = new Error("Failed to execute query");
-    // prepareメソッドをモックしてクエリエラーを発生させる
-    const prepareSpy = vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
-      throw queryError;
+    afterEach(() => {
+      vi.restoreAllMocks();
     });
 
-    const [request, context] = createGetRequest("1");
-    const response = await GET(request, context);
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
-    );
+    const errorTestCases: ErrorTestCase<string>[] = [
+      {
+        description: "不正なIDの場合400エラーを返す",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        errorMessage: "IDは正の整数である必要があります。",
+        logMessage: "Invalid ID provided: abc. It must be a positive integer.",
+        body: "abc",
+      },
+      {
+        description: "存在しないIDの場合404エラーを返す",
+        statusCode: HTTP_STATUS_NOT_FOUND,
+        errorMessage: "指定されたブックマークがありません。",
+        logMessage: "Bookmark with id: 100 not found.",
+        body: "100",
+      },
+      {
+        description: "データベース接続エラーの場合500エラーを返す",
+        statusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        errorMessage: "サーバー内部でエラーが発生しました。",
+        logMessage: "Internal Server Error: Database connection failed",
+        body: "1",
+        setup: () => {
+          vi.mocked(getDb).mockImplementation(() => {
+            throw new Error("Database connection failed");
+          });
+        },
+      },
+      {
+        description: "クエリエラー時に500エラーを返す",
+        statusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        errorMessage: "サーバー内部でエラーが発生しました。",
+        logMessage: "Internal Server Error: Failed to execute query",
+        body: "1",
+        setup: () => {
+          vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
+            throw new Error("Failed to execute query");
+          });
+        },
+      },
+    ];
 
-    prepareSpy.mockRestore();
+    it.each(errorTestCases)(
+      "$description",
+      async ({ setup, body, statusCode, errorMessage, logMessage }) => {
+        if (setup) {
+          setup();
+        }
+
+        const [request, context] = createGetRequest(body);
+        const response = await GET(request, context);
+
+        await assertErrorResponse(response, statusCode, errorMessage);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(logMessage);
+      }
+    );
   });
 });

--- a/src/app/api/bookmarks/[bookmark_id]/keywords/post.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/keywords/post.test.ts
@@ -1,6 +1,6 @@
 import ActualDatabase from "better-sqlite3"; // 実際のライブラリをインポート
 import { NextRequest } from "next/server";
-import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import {
   HTTP_STATUS_BAD_REQUEST,
@@ -12,6 +12,7 @@ import {
 import { assertErrorResponse } from "../../../../test-utils/assertions";
 import { setupInMemoryDb } from "../../../../test-utils/db-setup";
 import { isKeyword, KeywordPostParams } from "../../../../types/Keyword";
+import { ErrorTestCase } from "../../../utils/types";
 import { getDb } from "../../database";
 
 vi.mock("../../database");
@@ -129,25 +130,43 @@ describe("POST /api/bookmarks/[bookmark_id]/keywords", () => {
 
   // // 異常系テスト
   describe("Error cases", () => {
-    it("should return 404 if bookmark_id does not exist", async () => {
-      const request = mockRequest({ keyword_name: "test-keyword" });
-      const response = await POST(request, getPostParams("999"));
-      await assertErrorResponse(
-        response,
-        HTTP_STATUS_NOT_FOUND,
-        "指定されたブックマークがありません。"
-      );
+    let consoleErrorSpy: MockInstance;
+
+    beforeEach(() => {
+      // console.errorをスパイして、エラー出力がされるか確認
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    it("should return 400 if bookmark_id is invalid", async () => {
-      const request = mockRequest({ keyword_name: "test-keyword" });
-      const response = await POST(request, getPostParams("invalid"));
-      await assertErrorResponse(
-        response,
-        HTTP_STATUS_BAD_REQUEST,
-        "IDは正の整数である必要があります。"
-      );
+    afterEach(() => {
+      vi.restoreAllMocks();
     });
+
+    const errorTestCases: ErrorTestCase<string>[] = [
+      {
+        description: "存在しないIDの場合は404エラーを返す",
+        statusCode: HTTP_STATUS_NOT_FOUND,
+        errorMessage: "指定されたブックマークがありません。",
+        logMessage: "Bookmark with id: 999 not found.",
+        body: "999",
+      },
+      {
+        description: "不正なIDの場合は400エラーを返す",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        errorMessage: "IDは正の整数である必要があります。",
+        logMessage: "Invalid ID provided: abc. It must be a positive integer.",
+        body: "abc",
+      },
+    ];
+
+    it.each(errorTestCases)(
+      "$description",
+      async ({ statusCode, errorMessage, logMessage, body }) => {
+        const request = mockRequest({ keyword_name: "test-keyword" });
+        const response = await POST(request, getPostParams(body));
+        await assertErrorResponse(response, statusCode, errorMessage);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(logMessage);
+      }
+    );
 
     it("should return 400 if request body is not valid JSON", async () => {
       const request = {
@@ -162,6 +181,7 @@ describe("POST /api/bookmarks/[bookmark_id]/keywords", () => {
         HTTP_STATUS_BAD_REQUEST,
         "リクエストボディのJSONが不正です。"
       );
+      expect(consoleErrorSpy).toHaveBeenCalledWith("Invalid JSON format: Invalid JSON");
     });
 
     it.each([
@@ -176,6 +196,7 @@ describe("POST /api/bookmarks/[bookmark_id]/keywords", () => {
         HTTP_STATUS_BAD_REQUEST,
         "キーワードを指定してください。"
       );
+      expect(consoleErrorSpy).toHaveBeenCalledWith("キーワードが指定されていません。");
     });
 
     it("should return 409 if the keyword is already associated with the bookmark", async () => {
@@ -202,6 +223,9 @@ describe("POST /api/bookmarks/[bookmark_id]/keywords", () => {
         HTTP_STATUS_CONFLICT,
         "指定されたキーワードは既にこのブックマークに登録されています。"
       );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Keyword "duplicate-keyword" is already associated with bookmark id: 1.'
+      );
     });
 
     it("should handle internal server errors gracefully", async () => {
@@ -218,6 +242,7 @@ describe("POST /api/bookmarks/[bookmark_id]/keywords", () => {
         HTTP_STATUS_INTERNAL_SERVER_ERROR,
         "サーバー内部でエラーが発生しました。"
       );
+      expect(consoleErrorSpy).toHaveBeenCalledWith("Internal Server Error: Database error");
     });
   });
 });

--- a/src/app/api/bookmarks/[bookmark_id]/put.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/put.test.ts
@@ -1,5 +1,5 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import {
   HTTP_STATUS_BAD_REQUEST,
@@ -16,8 +16,10 @@ import {
 } from "../../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../../test-utils/db-setup";
 import { API_BOOKMARKS_URL } from "../../utils/constants";
+import { ErrorTestCase } from "../../utils/types";
 import { getDb } from "../database";
 import { PUT } from "./route";
+import { Bookmark } from "../../../types/Bookmark";
 
 // We will mock getDb to return our in-memory instance.
 // The actual getDb function is simple, but mocking allows us to inject the in-memory DB.
@@ -124,184 +126,184 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
     expect(countAfter).toBe(mockBookmarks.length);
   });
 
-  it("PUT: 登録されていないブックマークIDを指定された場合は404を返す。", async () => {
-    const bookmarkToUpdate = {
-      bookmark_id: 999,
-      url: "https://www.example.com",
-      title: "Example Title",
-    };
-
-    const [request, context] = createPutRequest(
-      JSON.stringify({
-        url: bookmarkToUpdate.url,
-        title: bookmarkToUpdate.title,
-      }),
-      bookmarkToUpdate.bookmark_id
-    );
-    const response = await PUT(request, context);
-
-    // レスポンスステータスを確認 (404 Not Found)
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_NOT_FOUND,
-      "指定されたブックマークがありません。"
-    );
-  });
-
-  it("PUT: タイトルが指定されていない場合には400を返す。", async () => {
-    const bookmarkToUpdate = {
-      bookmark_id: 1,
-      url: "https://www.example.com",
-      title: "",
-    };
-
-    const [request, context] = createPutRequest(
-      JSON.stringify({
-        url: bookmarkToUpdate.url,
-        title: bookmarkToUpdate.title,
-      }),
-      bookmarkToUpdate.bookmark_id
-    );
-    const response = await PUT(request, context);
-
-    // レスポンスステータスを確認 (400: Bad Request)
-    await assertErrorResponse(response, HTTP_STATUS_BAD_REQUEST, "タイトルを指定してください。");
-  });
-
-  it("PUT: URLが指定されていない場合には400を返す。", async () => {
-    const bookmarkToUpdate = {
-      bookmark_id: 1,
-      url: "",
-      title: "Example Title",
-    };
-
-    const [request, context] = createPutRequest(
-      JSON.stringify({
-        url: bookmarkToUpdate.url,
-        title: bookmarkToUpdate.title,
-      }),
-      bookmarkToUpdate.bookmark_id
-    );
-    const response = await PUT(request, context);
-
-    // レスポンスステータスを確認 (400: Bad Request)
-    await assertErrorResponse(response, HTTP_STATUS_BAD_REQUEST, "URLを指定してください。");
-  });
-
-  it("PUT: IDが指定されていない場合には400を返す。", async () => {
-    const bookmarkToUpdate = {
-      url: "https://www.example.com",
-      title: "Example Title",
-    };
-
-    const [request] = createPutRequest(
-      JSON.stringify({
-        url: bookmarkToUpdate.url,
-        title: bookmarkToUpdate.title,
-      }),
-      0 // ダミーのID。params.idが優先されるため、この値は影響しない
-    );
-    const response = await PUT(request, {
-      params: Promise.resolve({ bookmark_id: "" }),
+  describe("PUT: エラーログが出力される場合のテスト", () => {
+    let consoleErrorSpy: MockInstance;
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    // レスポンスステータスを確認 (400: Bad Request)
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_BAD_REQUEST,
-      "IDは正の整数である必要があります。"
-    );
-  });
-
-  it("PUT: 不正な形式(文字列)のIDが指定された場合には400を返す。", async () => {
-    const bookmarkToUpdate = {
-      id: 1,
-      url: "https://www.example.com",
-      title: "Example Title",
-    };
-
-    const [request] = createPutRequest(
-      JSON.stringify({
-        url: bookmarkToUpdate.url,
-        title: bookmarkToUpdate.title,
-      }),
-      bookmarkToUpdate.id
-    );
-    const response = await PUT(request, {
-      params: Promise.resolve({ bookmark_id: "invalid id" }),
+    afterEach(() => {
+      vi.restoreAllMocks();
     });
 
-    // レスポンスステータスを確認 (400: Bad Request)
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_BAD_REQUEST,
-      "IDは正の整数である必要があります。"
+    const errorTestCases: ErrorTestCase<Bookmark>[] = [
+      {
+        description: "登録されていないブックマークIDを指定された場合は404を返す。",
+        statusCode: HTTP_STATUS_NOT_FOUND,
+        errorMessage: "指定されたブックマークがありません。",
+        logMessage: "Bookmark with id: 999 not found.",
+        body: {
+          bookmark_id: 999,
+          url: "https://www.example.com",
+          title: "Example Title",
+          keywords: [],
+        },
+      },
+      {
+        description: "タイトルが指定されていない場合には400を返す。",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        errorMessage: "タイトルを指定してください。",
+        logMessage: "タイトルが指定されていません。",
+        body: {
+          bookmark_id: 1,
+          url: "https://www.example.com",
+          title: "",
+          keywords: [],
+        },
+      },
+      {
+        description: "URLが指定されていない場合には400を返す。",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        errorMessage: "URLを指定してください。",
+        logMessage: "URLが指定されていません。",
+        body: {
+          bookmark_id: 1,
+          url: "",
+          title: "Example Title",
+          keywords: [],
+        },
+      },
+      {
+        description: "クエリエラー時に500エラーを返す",
+        statusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        errorMessage: "サーバー内部でエラーが発生しました。",
+        logMessage: "Internal Server Error: Failed to execute query",
+        body: {
+          bookmark_id: 1,
+          url: "https://www.example.com",
+          title: "Example Title",
+          keywords: [],
+        },
+        setup: () => {
+          // prepareメソッドをモックしてクエリエラーを発生
+          vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
+            throw new Error("Failed to execute query");
+          });
+        },
+      },
+      {
+        description: "同じURLが登録される場合には409を返す。",
+        statusCode: HTTP_STATUS_CONFLICT,
+        errorMessage: "指定されたURLのブックマークは既に登録されています。",
+        logMessage: 'Bookmark with URL "https://mail.google.com" already exists.',
+        body: {
+          bookmark_id: 1,
+          url: GMAIL_BOOKMARK.url,
+          title: "Example Title",
+          keywords: [],
+        },
+      },
+    ];
+
+    it.each(errorTestCases)(
+      "$description",
+      async ({ setup, body, statusCode, errorMessage, logMessage }) => {
+        if (setup) {
+          setup();
+        }
+        const [request, context] = createPutRequest(
+          JSON.stringify({
+            url: body.url,
+            title: body.title,
+          }),
+          body.bookmark_id
+        );
+        const response = await PUT(request, context);
+
+        // レスポンスステータスを確認 (404 Not Found)
+        await assertErrorResponse(response, statusCode, errorMessage);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(logMessage);
+      }
     );
-  });
 
-  it("PUT: 不正なJSONデータの場合は400を返す。", async () => {
-    const bookmarkToUpdate = {
-      bookmark_id: 1,
-      url: "https://www.example.com",
-      title: "Example Title",
-    };
-
-    const [request, context] = createPutRequest("invalid json data", bookmarkToUpdate.bookmark_id);
-    const response = await PUT(request, context);
-
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_BAD_REQUEST,
-      "リクエストボディのJSONが不正です。"
-    );
-  });
-
-  it("PUT: クエリエラー時に500エラーを返す", async () => {
-    const queryError = new Error("Failed to execute query");
-    // prepareメソッドをモックしてクエリエラーを発生させる
-    const prepareSpy = vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
-      throw queryError;
-    });
-
-    const bookmarkToUpdate = {
-      bookmark_id: 1,
-      url: "https://www.example.com",
-      title: "Example Title",
-    };
-
-    const [request, context] = createPutRequest(
-      JSON.stringify({
-        url: bookmarkToUpdate.url,
-        title: bookmarkToUpdate.title,
-      }),
-      bookmarkToUpdate.bookmark_id
-    );
-    const response = await PUT(request, context);
-
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
-    );
-
-    prepareSpy.mockRestore();
-  });
-
-  it("PUT: 同じURLが登録される場合には409を返す。", async () => {
-    const [request, context] = createPutRequest(
-      JSON.stringify({
-        url: GMAIL_BOOKMARK.url,
+    it("PUT: IDが指定されていない場合には400を返す。", async () => {
+      const bookmarkToUpdate = {
+        url: "https://www.example.com",
         title: "Example Title",
-      }),
-      LINKPAGE_BOOKMARK.bookmark_id
-    );
-    const response = await PUT(request, context);
+      };
 
-    // レスポンスステータスを確認 (409: Conflict
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_CONFLICT,
-      "指定されたURLのブックマークは既に登録されています。"
-    );
+      const [request] = createPutRequest(
+        JSON.stringify({
+          url: bookmarkToUpdate.url,
+          title: bookmarkToUpdate.title,
+        }),
+        0 // ダミーのID。params.idが優先されるため、この値は影響しない
+      );
+      const response = await PUT(request, {
+        params: Promise.resolve({ bookmark_id: "" }),
+      });
+
+      // レスポンスステータスを確認 (400: Bad Request)
+      await assertErrorResponse(
+        response,
+        HTTP_STATUS_BAD_REQUEST,
+        "IDは正の整数である必要があります。"
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Invalid ID provided: . It must be a positive integer."
+      );
+    });
+
+    it("PUT: 不正な形式(文字列)のIDが指定された場合には400を返す。", async () => {
+      const bookmarkToUpdate = {
+        id: 1,
+        url: "https://www.example.com",
+        title: "Example Title",
+      };
+
+      const [request] = createPutRequest(
+        JSON.stringify({
+          url: bookmarkToUpdate.url,
+          title: bookmarkToUpdate.title,
+        }),
+        bookmarkToUpdate.id
+      );
+      const response = await PUT(request, {
+        params: Promise.resolve({ bookmark_id: "invalid id" }),
+      });
+
+      // レスポンスステータスを確認 (400: Bad Request)
+      await assertErrorResponse(
+        response,
+        HTTP_STATUS_BAD_REQUEST,
+        "IDは正の整数である必要があります。"
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Invalid ID provided: invalid id. It must be a positive integer."
+      );
+    });
+
+    it("PUT: 不正なJSONデータの場合は400を返す。", async () => {
+      const bookmarkToUpdate = {
+        bookmark_id: 1,
+        url: "https://www.example.com",
+        title: "Example Title",
+      };
+
+      const [request, context] = createPutRequest(
+        "invalid json data",
+        bookmarkToUpdate.bookmark_id
+      );
+      const response = await PUT(request, context);
+
+      await assertErrorResponse(
+        response,
+        HTTP_STATUS_BAD_REQUEST,
+        "リクエストボディのJSONが不正です。"
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid JSON format: Unexpected token")
+      );
+    });
   });
 });

--- a/src/app/api/bookmarks/get.test.ts
+++ b/src/app/api/bookmarks/get.test.ts
@@ -1,10 +1,11 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import { HTTP_STATUS_INTERNAL_SERVER_ERROR, HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../test-utils/assertions";
 import { expectEqualBookmark, mockBookmarks } from "../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../test-utils/db-setup";
+import { ErrorTestCase } from "../utils/types";
 import { getDb } from "./database";
 import { GET } from "./route";
 
@@ -41,34 +42,57 @@ describe("ブックマークのAPIのテスト", () => {
     });
   });
 
-  it("GET: データベースエラー時に500エラーを返す", async () => {
-    const dbError = new Error("Database connection failed");
-    vi.mocked(getDb).mockImplementation(() => {
-      throw dbError;
+  describe("GET: エラーログが出力される場合のテスト", () => {
+    let consoleErrorSpy: MockInstance;
+
+    beforeEach(() => {
+      // console.errorをスパイして、エラー出力がされるか確認
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    const response = await GET();
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
-    );
-  });
-
-  it("GET: クエリエラー時に500エラーを返す", async () => {
-    const queryError = new Error("Failed to execute query");
-    // prepareメソッドをモックしてクエリエラーを発生させる
-    const prepareSpy = vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
-      throw queryError;
+    afterEach(() => {
+      vi.restoreAllMocks();
     });
 
-    const response = await GET();
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
-    );
+    const errorTestCases: ErrorTestCase<null>[] = [
+      {
+        description: "データベースエラー時に500エラーを返す",
+        statusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        errorMessage: "サーバー内部でエラーが発生しました。",
+        logMessage: "Internal Server Error: Database connection failed",
+        body: null,
+        setup: () => {
+          // getDbをモックして、データベースエラーを発生させる
+          vi.mocked(getDb).mockImplementation(() => {
+            throw new Error("Database connection failed");
+          });
+        },
+      },
+      {
+        description: "クエリエラー時に500エラーを返す",
+        statusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        errorMessage: "サーバー内部でエラーが発生しました。",
+        logMessage: "Internal Server Error: Failed to execute query",
+        body: null,
+        setup: () => {
+          // prepareメソッドをモックしてクエリエラーを発生させる
+          vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
+            throw new Error("Failed to execute query");
+          });
+        },
+      },
+    ];
 
-    prepareSpy.mockRestore();
+    it.each(errorTestCases)(
+      "$description",
+      async ({ setup, statusCode, errorMessage, logMessage }) => {
+        if (setup) {
+          setup();
+        }
+        const response = await GET();
+        await assertErrorResponse(response, statusCode, errorMessage);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(logMessage);
+      }
+    );
   });
 });

--- a/src/app/api/bookmarks/post.test.ts
+++ b/src/app/api/bookmarks/post.test.ts
@@ -1,5 +1,5 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import {
   HTTP_STATUS_BAD_REQUEST,
@@ -13,6 +13,7 @@ import { createBookmark, GOOGLE_BOOKMARK } from "../../test-utils/bookmarkTestUt
 import { setupInMemoryDb } from "../../test-utils/db-setup";
 import { Bookmark } from "../../types/Bookmark";
 import { API_BOOKMARKS_URL } from "../utils/constants";
+import { ErrorTestCase } from "../utils/types";
 import { getDb } from "./database";
 import { OPTIONS, POST } from "./route";
 
@@ -94,71 +95,85 @@ describe("ブックマーク追加APIのテスト (オンメモリDB)", () => {
     );
   });
 
-  it("POST: 不正なJSONデータの場合はエラーを返す", async () => {
-    const response = await POST(createPostRequest("invalid json"));
+  describe("POST: エラーログが出力される場合のテスト", () => {
+    let consoleErrorSpy: MockInstance;
 
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_BAD_REQUEST,
-      "リクエストボディのJSONが不正です。"
+    beforeEach(() => {
+      // console.errorをスパイして、エラー出力がされるか確認
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    const errorTestCases: ErrorTestCase<Partial<Bookmark> | string>[] = [
+      {
+        description: "不正なJSONデータの場合",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        errorMessage: "リクエストボディのJSONが不正です。",
+        logMessage: expect.stringContaining("Invalid JSON format"),
+        body: "invalid json",
+      },
+      {
+        description: "データベースエラー時に500エラーを返す",
+        statusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        errorMessage: "サーバー内部でエラーが発生しました。",
+        logMessage: "Internal Server Error: Failed to execute query",
+        body: {
+          url: "https://www2.example.com",
+          title: "サンプルのタイトル2",
+        },
+        setup: () => {
+          // prepareメソッドをモックしてクエリエラーを発生させる
+          vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
+            throw new Error("Failed to execute query");
+          });
+        },
+      },
+      {
+        description: "重複したURLのブックマーク追加時に409 Conflictを返す",
+        statusCode: HTTP_STATUS_CONFLICT,
+        errorMessage: "指定されたURLのブックマークは既に登録されています。",
+        logMessage: `Bookmark with URL "${GOOGLE_BOOKMARK.url}" already exists.`,
+        body: {
+          url: GOOGLE_BOOKMARK.url, // Same URL
+          title: "同じURLで別のタイトル",
+        },
+      },
+      {
+        description: "URLが空文字の場合にエラーを返す",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        errorMessage: "URLを指定してください。",
+        logMessage: "URLが指定されていません。",
+        body: {
+          title: "Example",
+        },
+      },
+      {
+        description: "タイトルが空文字の場合にエラーを返す",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        errorMessage: "タイトルを指定してください。",
+        logMessage: "タイトルが指定されていません。",
+        body: {
+          url: "https://example.com",
+        },
+      },
+    ];
+
+    it.each(errorTestCases)(
+      "$description",
+      async ({ setup, body, statusCode, errorMessage, logMessage }) => {
+        if (setup) {
+          setup();
+        }
+
+        const requestBody = typeof body === "string" ? body : JSON.stringify(createBookmark(body));
+        const response = await POST(createPostRequest(requestBody));
+        await assertErrorResponse(response, statusCode, errorMessage);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(logMessage);
+      }
     );
-  });
-
-  it("POST: クエリエラー時に500エラーを返す", async () => {
-    const queryError = new Error("Failed to execute query");
-    // prepareメソッドをモックしてクエリエラーを発生させる
-    const prepareSpy = vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
-      throw queryError;
-    });
-
-    const bookmark: Bookmark = createBookmark({
-      url: "https://www2.example.com",
-      title: "サンプルのタイトル2",
-    });
-
-    const response = await POST(createPostRequest(JSON.stringify(bookmark)));
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
-    );
-
-    prepareSpy.mockRestore();
-  });
-
-  it("POST: 重複したURLのブックマーク追加時に409 Conflictを返す", async () => {
-    const bookmark: Bookmark = createBookmark({
-      url: GOOGLE_BOOKMARK.url, // Same URL
-      title: "同じURLで別のタイトル",
-    });
-
-    const response = await POST(createPostRequest(JSON.stringify(bookmark)));
-
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_CONFLICT,
-      "指定されたURLのブックマークは既に登録されています。"
-    );
-  });
-
-  it("POST: URLが空文字の場合にエラーを返す", async () => {
-    const bookmark: Bookmark = createBookmark({
-      title: "Example",
-    });
-
-    const response = await POST(createPostRequest(JSON.stringify(bookmark)));
-
-    await assertErrorResponse(response, HTTP_STATUS_BAD_REQUEST, "URLを指定してください。");
-  });
-
-  it("POST: タイトルが空文字の場合にエラーを返す", async () => {
-    const bookmark: Bookmark = createBookmark({
-      url: "https://example.com",
-    });
-
-    const response = await POST(createPostRequest(JSON.stringify(bookmark)));
-
-    await assertErrorResponse(response, HTTP_STATUS_BAD_REQUEST, "タイトルを指定してください。");
   });
 
   // --- OPTIONS Tests ---

--- a/src/app/api/bookmarks/route.ts
+++ b/src/app/api/bookmarks/route.ts
@@ -84,8 +84,7 @@ export async function POST(request: Request) {
     incomingData = await request.json();
   } catch (error) {
     // JSONパースエラーのハンドリング
-    console.error(error);
-    return createInvalidBodyError(new Error("リクエストボディのJSONが不正です。"), commonHeaders);
+    return createInvalidBodyError(error, commonHeaders);
   }
   try {
     // incomingDataがオブジェクトでない場合(例: JSONが "null" だった場合)を考慮します
@@ -134,9 +133,6 @@ export async function POST(request: Request) {
       }
     );
   } catch (error: unknown) {
-    if (error instanceof SyntaxError) {
-      return createInvalidBodyError(error, commonHeaders);
-    }
     if (error instanceof SqliteError && error.code === "SQLITE_CONSTRAINT_UNIQUE") {
       return createDuplicateBookmarkError(incomingData.url, commonHeaders);
     }

--- a/src/app/api/keywords/[keyword_id]/delete.test.ts
+++ b/src/app/api/keywords/[keyword_id]/delete.test.ts
@@ -1,5 +1,5 @@
 import ActualDatabase from "better-sqlite3";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import {
   HTTP_STATUS_BAD_REQUEST,
@@ -15,8 +15,6 @@ import { DELETE } from "./route";
 
 vi.mock("../../bookmarks/database");
 
-let inMemoryDbInstance: ActualDatabase.Database;
-
 const createDeleteRequest = (
   keyword_id: string
 ): [Request, { params: Promise<{ keyword_id: string }> }] => {
@@ -27,6 +25,8 @@ const createDeleteRequest = (
 };
 
 describe("キーワードDELETE APIのテスト", () => {
+  let inMemoryDbInstance: ActualDatabase.Database;
+
   beforeEach(() => {
     vi.resetAllMocks();
     inMemoryDbInstance = setupInMemoryDb();
@@ -40,48 +40,80 @@ describe("キーワードDELETE APIのテスト", () => {
   });
 
   it("DELETE: 正常にキーワードが削除できる", async () => {
-    const [req, ctx] = createDeleteRequest("1");
+    const keywordId = "1";
+    const [req, ctx] = createDeleteRequest(keywordId);
     const response = await DELETE(req, ctx);
     expect(response.status).toBe(HTTP_STATUS_NO_CONTENT);
-    // 削除後にもう一度削除を試みると404になることを確認
-    const response2 = await DELETE(req, ctx);
-    await assertErrorResponse(
-      response2,
-      HTTP_STATUS_NOT_FOUND,
-      "指定されたキーワードが見つかりません。"
-    );
+
+    // データベースから削除されたことを確認
+    const stmt = inMemoryDbInstance.prepare("SELECT keyword_id FROM keywords WHERE keyword_id = ?");
+    const dbData = stmt.get(keywordId);
+    expect(dbData).toBeUndefined();
   });
 
-  it("DELETE: 存在しないIDの場合404を返す", async () => {
-    const [req, ctx] = createDeleteRequest("9999");
-    const response = await DELETE(req, ctx);
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_NOT_FOUND,
-      "指定されたキーワードが見つかりません。"
-    );
-  });
-
-  it("DELETE: 不正なIDの場合400を返す", async () => {
-    const [req, ctx] = createDeleteRequest("abc");
-    const response = await DELETE(req, ctx);
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_BAD_REQUEST,
-      "IDは正の整数である必要があります。"
-    );
-  });
-
-  it("DELETE: DBエラー時は500を返す", async () => {
-    vi.mocked(getDb).mockImplementation(() => {
-      throw new Error("DB error");
+  describe("エラーログが出力される場合のテスト", () => {
+    let consoleErrorSpy: MockInstance;
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
-    const [req, ctx] = createDeleteRequest("1");
-    const response = await DELETE(req, ctx);
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    const setupErrorCases = [
+      {
+        description: "削除済みのIDで再度削除しようした場合",
+        keywordId: "1",
+        statusCode: HTTP_STATUS_NOT_FOUND,
+        errorMessage: "指定されたキーワードが見つかりません。",
+        logMessage: "Keyword with id: 1 not found.",
+        setup: async (keywordId: string) => {
+          const [req, ctx] = createDeleteRequest(keywordId);
+          await DELETE(req, ctx); // 1回目の削除 (keywordId "1" を使用)
+        },
+      },
+      {
+        description: "存在しないIDを指定した場合",
+        keywordId: "9999",
+        statusCode: HTTP_STATUS_NOT_FOUND,
+        errorMessage: "指定されたキーワードが見つかりません。",
+        logMessage: "Keyword with id: 9999 not found.",
+        setup: undefined,
+      },
+      {
+        description: "不正なIDを指定した場合",
+        keywordId: "abc",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        errorMessage: "IDは正の整数である必要があります。",
+        logMessage: "Invalid ID provided: abc. It must be a positive integer.",
+        setup: undefined,
+      },
+      {
+        description: "DBエラーが発生した場合",
+        keywordId: "1",
+        statusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        errorMessage: "サーバー内部でエラーが発生しました。",
+        logMessage: "Internal Server Error: DB Error",
+        setup: () => {
+          vi.mocked(getDb).mockImplementation(() => {
+            throw new Error("DB Error");
+          });
+        },
+      },
+    ];
+
+    it.each(setupErrorCases)(
+      `$descriptionに$statusCodeでエラーメッセージが返る`,
+      async ({ setup, keywordId, statusCode, errorMessage, logMessage }) => {
+        if (setup) {
+          await setup(keywordId);
+        }
+        const [req, ctx] = createDeleteRequest(keywordId);
+        const response = await DELETE(req, ctx);
+        await assertErrorResponse(response, statusCode, errorMessage);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(logMessage);
+      }
     );
   });
 });

--- a/src/app/api/keywords/get.test.ts
+++ b/src/app/api/keywords/get.test.ts
@@ -1,5 +1,5 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import { HTTP_STATUS_INTERNAL_SERVER_ERROR, HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import { assertErrorResponse } from "../../test-utils/assertions";
@@ -36,34 +36,53 @@ describe("キーワードGET APIのテスト", () => {
     expect(json).toEqual(mockKeywords);
   });
 
-  it("GET: データベースエラー時に500エラーを返す", async () => {
-    const dbError = new Error("Database connection failed");
-    vi.mocked(getDb).mockImplementation(() => {
-      throw dbError;
+  describe("GET: エラーログが出力される場合のテスト", () => {
+    let consoleErrorSpy: MockInstance;
+
+    beforeEach(() => {
+      // console.errorをスパイして、エラー出力がされるか確認
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    const response = await GET();
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
-    );
-  });
-
-  it("GET: クエリエラー時に500エラーを返す", async () => {
-    const queryError = new Error("Failed to execute query");
-    // prepareメソッドをモックしてクエリエラーを発生させる
-    const prepareSpy = vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
-      throw queryError;
+    afterEach(() => {
+      vi.restoreAllMocks();
     });
 
-    const response = await GET();
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
-    );
+    const errorTestCases = [
+      {
+        description: "データベースエラー時に500エラーを返す",
+        setup: () => {
+          const errorMessage = "Database connection failed";
+          // getDbをモックして、データベースエラーを発生させる
+          vi.mocked(getDb).mockImplementation(() => {
+            throw new Error(errorMessage);
+          });
+          return errorMessage;
+        },
+      },
+      {
+        description: "クエリエラー時に500エラーを返す",
+        setup: () => {
+          const errorMessage = "Failed to execute query";
+          // prepareメソッドをモックしてクエリエラーを発生させる
+          vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
+            throw new Error(errorMessage);
+          });
+          return errorMessage;
+        },
+      },
+    ];
 
-    prepareSpy.mockRestore();
+    it.each(errorTestCases)("$description", async ({ setup }) => {
+      const errorMessage = setup();
+      const response = await GET();
+
+      await assertErrorResponse(
+        response,
+        HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        "サーバー内部でエラーが発生しました。"
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(`Internal Server Error: ${errorMessage}`);
+    });
   });
 });

--- a/src/app/api/keywords/post.test.ts
+++ b/src/app/api/keywords/post.test.ts
@@ -12,6 +12,7 @@ import { mockKeywords } from "../../test-utils/bookmarkTestUtils";
 import { setupInMemoryDb } from "../../test-utils/db-setup";
 import { getDb } from "../bookmarks/database";
 import { API_KEYWORDS_URL } from "../utils/constants";
+import { ErrorTestCase } from "../utils/types";
 import { POST } from "./route";
 
 vi.mock("../bookmarks/database");
@@ -86,20 +87,20 @@ describe("キーワードAPIのテスト", () => {
       vi.restoreAllMocks();
     });
 
-    const invalidRequestTestCases = [
+    const invalidRequestTestCases: ErrorTestCase<string>[] = [
       {
         description: "不正なJSONデータ(JSON.parseエラー)",
         statusCode: HTTP_STATUS_BAD_REQUEST,
         body: "invalid json",
         errorMessage: "リクエストボディのJSONが不正です。",
-        logMessage: expect.stringContaining("Invalid JSON format: Unexpected token"),
+        logMessage: "Invalid JSON format: リクエストボディのJSONが不正です。",
       },
       {
         description: "不正なJSONデータ(null)",
         statusCode: HTTP_STATUS_BAD_REQUEST,
         body: JSON.stringify(null),
-        errorMessage: "リクエストボディのJSONが不正です。",
-        logMessage: "Invalid JSON format: リクエストボディのJSONが不正です。",
+        errorMessage: "キーワードを指定してください。",
+        logMessage: "キーワードが指定されていません。",
       },
       {
         description: "重複したキーワードを追加",

--- a/src/app/api/keywords/post.test.ts
+++ b/src/app/api/keywords/post.test.ts
@@ -1,5 +1,5 @@
 import ActualDatabase from "better-sqlite3"; // Import the actual library
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import {
   HTTP_STATUS_BAD_REQUEST,
@@ -74,64 +74,74 @@ describe("キーワードAPIのテスト", () => {
     await assertErrorResponse(response, HTTP_STATUS_BAD_REQUEST, "キーワードを指定してください。");
   });
 
-  it("POST: 不正なJSONデータ(JSON.parseエラー)の場合は400を返す", async () => {
-    const response = await POST(
-      new Request(API_KEYWORDS_URL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: "invalid json",
-      })
-    );
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_BAD_REQUEST,
-      "リクエストボディのJSONが不正です。"
-    );
-  });
+  describe("POST: エラーログが出力される場合のテスト", () => {
+    let consoleErrorSpy: MockInstance;
 
-  it("POST: 不正なJSONデータ(null)の場合は400を返す", async () => {
-    const response = await POST(
-      new Request(API_KEYWORDS_URL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(null),
-      })
-    );
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_BAD_REQUEST,
-      "リクエストボディのJSONが不正です。"
-    );
-  });
-
-  it("POST: 重複したキーワードを追加時に409 Conflictを返す", async () => {
-    const response = await POST(createPostRequest(mockKeywords[0].keyword_name));
-
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_CONFLICT,
-      "指定されたキーワードは既に登録されています。"
-    );
-  });
-
-  it("POST: データベースエラー時に500エラーを返す", async () => {
-    const queryError = new Error("Failed to execute query");
-    // prepareメソッドをモックしてクエリエラーを発生させる
-    const prepareSpy = vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
-      throw queryError;
+    beforeEach(() => {
+      // console.errorをスパイして、エラー出力がされるか確認
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    const response = await POST(createPostRequest("テスト"));
-    await assertErrorResponse(
-      response,
-      HTTP_STATUS_INTERNAL_SERVER_ERROR,
-      "サーバー内部でエラーが発生しました。"
-    );
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
 
-    prepareSpy.mockRestore();
+    const invalidRequestTestCases = [
+      {
+        description: "不正なJSONデータ(JSON.parseエラー)",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        body: "invalid json",
+        errorMessage: "リクエストボディのJSONが不正です。",
+        logMessage: expect.stringContaining("Invalid JSON format: Unexpected token"),
+      },
+      {
+        description: "不正なJSONデータ(null)",
+        statusCode: HTTP_STATUS_BAD_REQUEST,
+        body: JSON.stringify(null),
+        errorMessage: "リクエストボディのJSONが不正です。",
+        logMessage: "Invalid JSON format: リクエストボディのJSONが不正です。",
+      },
+      {
+        description: "重複したキーワードを追加",
+        statusCode: HTTP_STATUS_CONFLICT,
+        body: JSON.stringify({
+          keyword_name: mockKeywords[0].keyword_name,
+        }),
+        errorMessage: "指定されたキーワードは既に登録されています。",
+        logMessage: 'Keyword with "キーワード1" already exists.',
+      },
+      {
+        description: "データベースエラーが発生した場合",
+        statusCode: HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        body: JSON.stringify({ keyword_name: "テスト" }),
+        errorMessage: "サーバー内部でエラーが発生しました。",
+        logMessage: "Internal Server Error: Failed to execute query",
+        setup: () => {
+          vi.spyOn(inMemoryDbInstance, "prepare").mockImplementation(() => {
+            throw new Error("Failed to execute query");
+          });
+        },
+      },
+    ];
+
+    it.each(invalidRequestTestCases)(
+      `キーワードが$descriptionの場合は$statusCodeを返す`,
+      async ({ statusCode, body, errorMessage, logMessage, setup }) => {
+        if (setup) {
+          setup();
+        }
+        const response = await POST(
+          new Request(API_KEYWORDS_URL, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body,
+          })
+        );
+        await assertErrorResponse(response, statusCode, errorMessage);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(logMessage);
+      }
+    );
   });
 });

--- a/src/app/api/keywords/route.ts
+++ b/src/app/api/keywords/route.ts
@@ -32,18 +32,23 @@ export const POST = async (request: Request): Promise<Response> => {
   let rawBody: unknown;
   try {
     rawBody = await request.json();
-    // 型ガードを使用してrawBodyがKeywordInputの構造を持つか検証します。
-    // ここではKeywordInputが { keyword_name: string } であると仮定しています。
-    if (
-      typeof rawBody !== "object" ||
-      rawBody === null ||
-      !("keyword_name" in rawBody) ||
-      typeof (rawBody as { keyword_name: unknown }).keyword_name !== "string"
-    ) {
-      throw new Error("リクエストボディのJSONが不正です。");
-    }
-  } catch (error: unknown) {
-    return createInvalidBodyError(error);
+  } catch {
+    return createInvalidBodyError(new Error("リクエストボディのJSONが不正です。"));
+  }
+  // 型ガードを使用してrawBodyがKeywordInputの構造を持つか検証します。
+  // ここではKeywordInputが { keyword_name: string } であると仮定しています。
+  // まず、リクエストボディがオブジェクト形式でない場合（例: "foo", 123）を弾きます。
+  if (typeof rawBody !== "object") {
+    return createInvalidBodyError(new Error("リクエストボディのJSONが不正です。"));
+  }
+  // 次に、nullの場合や、必須プロパティ`keyword_name`が存在しない・型が違う場合を検証します。
+  // `typeof null` は "object" であるため、このチェックは必須です。
+  if (
+    rawBody === null ||
+    !("keyword_name" in rawBody) ||
+    typeof (rawBody as { keyword_name: unknown }).keyword_name !== "string"
+  ) {
+    return createNoKeywordError();
   }
 
   // 型ガードにより、rawBodyは安全にKeywordInputとして扱えます。

--- a/src/app/api/utils/types.ts
+++ b/src/app/api/utils/types.ts
@@ -1,0 +1,11 @@
+// src/app/api/utils/types.ts
+import { expect } from "vitest";
+
+export interface ErrorTestCase<T> {
+  description: string;
+  statusCode: number;
+  errorMessage: string;
+  logMessage: string | ReturnType<typeof expect.stringContaining>;
+  body: T;
+  setup?: () => void;
+}


### PR DESCRIPTION
## 概要
API全体のエラーハンドリングを改善し、関連するテストコードを大幅にリファクタリングします。 この変更により、APIの堅牢性と開発体験（テストの可読性・保守性）の向上を目指します。

## 主な変更点
1. APIエラーハンドリングの改善 (機能追加・修正)
  - キーワード追加APIの検証強化 (POST /api/keywords)
    - リクエストボディが null の場合や、keyword_name が未指定・不正な型の場合に、より具体的で分かりやすいエラーメッセージ「キーワードを指定してください。」を返すようにしました。
  - 不正なJSONボディのエラーメッセージ統一
    - JSONのパースに失敗した場合、これまでは内部的なエラー詳細がクライアントに返る可能性がありましたが、「リクエストボディのJSONが不正です。」という汎用的なメッセージに統一しました。これにより、意図しない情報漏洩を防ぎます。

2. テストコードのリファクタリング
  - データ駆動テストへの移行
    - 複数のAPIエンドポイント (/api/bookmarks, /api/keywords など) のエラーハンドリングテストを、it.each を用いたデータ駆動テストに全面的に書き換えました。
    - これにより、テストケースの追加や修正が容易になり、コードの重複が大幅に削減されました。
  - テストケースの型定義統一
    - 共通の ErrorTestCase 型 ([src/app/api/utils/types.ts](code-assist-path:/home/user1/projects/linkpage/src/app/api/utils/types.ts)) を導入し、APIテスト全体でテストケースの構造を統一しました。
  - エラーロギングの検証強化
    - console.error をスパイし、各エラーケースで期待されるログメッセージが出力されることを検証するアサーションを追加しました。

これらのリファクタリングにより、APIテストスイート全体の可読性、保守性、信頼性が大幅に向上しました。