### PR TITLE
feat(bookmark): ブックマークからキーワードを解除する機能を追加

### DIFF
--- a/src/app/hooks/useBookmark.ts
+++ b/src/app/hooks/useBookmark.ts
@@ -105,11 +105,40 @@ export const useBookmarks = () => {
     }
   }, []);
 
+  const unlinkKeyword = useCallback(async (bookmark_id: number, keyword_id: number) => {
+    try {
+      const response = await fetch(`${BOOKMARKS_ENDPOINT}/${bookmark_id}/keywords/${keyword_id}`, {
+        method: "DELETE",
+      });
+
+      if (response.ok) {
+        setBookmarks((currentBookmarks) =>
+          currentBookmarks.map((bookmark) =>
+            bookmark.bookmark_id === bookmark_id
+              ? {
+                  ...bookmark,
+                  keywords: bookmark.keywords.filter(
+                    (keyword) => keyword.keyword_id !== keyword_id
+                  ),
+                }
+              : bookmark
+          )
+        );
+      } else {
+        throw await parseApiError(response);
+      }
+    } catch (error: unknown) {
+      console.error("キーワードの解除エラー:", getErrorMessage(error));
+      throw error;
+    }
+  }, []);
+
   return {
     bookmarks,
     getBookmarks,
     deleteBookmark,
     updateBookmark,
     addKeyword,
+    unlinkKeyword,
   };
 };

--- a/src/app/hooks/useBookmark.unlink.test.tsx
+++ b/src/app/hooks/useBookmark.unlink.test.tsx
@@ -1,0 +1,83 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+import { useBookmarks } from "./useBookmark";
+import { mockBookmarks } from "../test-utils/bookmarkTestUtils";
+import { BOOKMARKS_ENDPOINT } from "../constants/apiEndpoints";
+
+global.fetch = vi.fn();
+
+describe("useBookmarks - unlinkKeyword", () => {
+  beforeEach(() => {
+    vi.mocked(fetch).mockClear();
+  });
+
+  it("should unlink a keyword from a bookmark and update the state", async () => {
+    // Arrange
+    const bookmarkId = 1;
+    const keywordId = 1;
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify(mockBookmarks), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const { result } = renderHook(() => useBookmarks());
+
+    // Act
+    await act(async () => {
+      await result.current.getBookmarks();
+    });
+
+    // Assert
+    expect(result.current.bookmarks.length).toBe(mockBookmarks.length);
+
+    // Act
+    await act(async () => {
+      await result.current.unlinkKeyword(bookmarkId, keywordId);
+    });
+
+    // Assert
+    await waitFor(() => {
+      const updatedBookmark = result.current.bookmarks.find((b) => b.bookmark_id === bookmarkId);
+      expect(updatedBookmark?.keywords.some((k) => k.keyword_id === keywordId)).toBe(false);
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${BOOKMARKS_ENDPOINT}/${bookmarkId}/keywords/${keywordId}`,
+      {
+        method: "DELETE",
+      }
+    );
+  });
+
+  it("should throw an error if unlinking a keyword fails", async () => {
+    // Arrange
+    const bookmarkId = 1;
+    const keywordId = 1;
+    const errorMessage = "Failed to unlink keyword";
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify(mockBookmarks), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: errorMessage }), { status: 500 })
+      );
+
+    const { result } = renderHook(() => useBookmarks());
+
+    // Act
+    await act(async () => {
+      await result.current.getBookmarks();
+    });
+
+    // Assert
+    expect(result.current.bookmarks.length).toBe(mockBookmarks.length);
+
+    // Act & Assert
+    await expect(result.current.unlinkKeyword(bookmarkId, keywordId)).rejects.toThrow();
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${BOOKMARKS_ENDPOINT}/${bookmarkId}/keywords/${keywordId}`,
+      {
+        method: "DELETE",
+      }
+    );
+  });
+});

--- a/src/app/hooks/useBookmark.unlink.test.tsx
+++ b/src/app/hooks/useBookmark.unlink.test.tsx
@@ -3,7 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "v
 import { act, renderHook, waitFor } from "@testing-library/react";
 
 import { BOOKMARKS_ENDPOINT } from "../constants/apiEndpoints";
-import { mockBookmarks } from "../test-utils/bookmarkTestUtils";
+import {
+  buildMockBookmarksWithKeywords,
+  mockBookmarks,
+  GOOGLE_BOOKMARK,
+  GOOGLE_KEYWORD_1,
+} from "../test-utils/bookmarkTestUtils";
 import { useBookmarks } from "./useBookmark";
 
 global.fetch = vi.fn();
@@ -15,10 +20,11 @@ describe("useBookmarks - unlinkKeyword", () => {
 
   it("should unlink a keyword from a bookmark and update the state", async () => {
     // Arrange
-    const bookmarkId = 1;
-    const keywordId = 1;
+    const bookmarkId = GOOGLE_BOOKMARK.bookmark_id;
+    const keywordId = GOOGLE_KEYWORD_1.keyword_id;
+    const mockDataWithKeywords = buildMockBookmarksWithKeywords();
     vi.mocked(fetch)
-      .mockResolvedValueOnce(new Response(JSON.stringify(mockBookmarks), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(mockDataWithKeywords), { status: 200 }))
       .mockResolvedValueOnce(new Response(null, { status: 204 }));
 
     const { result } = renderHook(() => useBookmarks());
@@ -28,15 +34,16 @@ describe("useBookmarks - unlinkKeyword", () => {
       await result.current.getBookmarks();
     });
 
-    // Assert
-    expect(result.current.bookmarks.length).toBe(mockBookmarks.length);
+    expect(result.current.bookmarks.length).toBe(mockDataWithKeywords.length);
+    const bookmarkBeforeUnlink = result.current.bookmarks.find((b) => b.bookmark_id === bookmarkId);
+    expect(bookmarkBeforeUnlink?.keywords.some((k) => k.keyword_id === keywordId)).toBe(true);
 
     // Act
     await act(async () => {
       await result.current.unlinkKeyword(bookmarkId, keywordId);
     });
 
-    // Assert
+    // Assert: キーワードが解除されたことを確認
     await waitFor(() => {
       const updatedBookmark = result.current.bookmarks.find((b) => b.bookmark_id === bookmarkId);
       expect(updatedBookmark?.keywords.some((k) => k.keyword_id === keywordId)).toBe(false);

--- a/src/app/hooks/useBookmark.unlink.test.tsx
+++ b/src/app/hooks/useBookmark.unlink.test.tsx
@@ -5,7 +5,6 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { BOOKMARKS_ENDPOINT } from "../constants/apiEndpoints";
 import {
   buildMockBookmarksWithKeywords,
-  mockBookmarks,
   GOOGLE_BOOKMARK,
   GOOGLE_KEYWORD_1,
 } from "../test-utils/bookmarkTestUtils";
@@ -66,7 +65,7 @@ describe("useBookmarks - unlinkKeyword", () => {
     });
 
     afterEach(() => {
-      vi.restoreAllMocks();
+      consoleErrorSpy.mockRestore();
     });
 
     const errorTestCase: { description: string; status?: number; errorMessage: string }[] = [
@@ -104,11 +103,12 @@ describe("useBookmarks - unlinkKeyword", () => {
 
     it.each(errorTestCase)("$description", async ({ status, errorMessage }) => {
       // Arrange
-      const bookmarkId = 1;
-      const keywordId = 1;
+      const bookmarkId = GOOGLE_BOOKMARK.bookmark_id;
+      const keywordId = GOOGLE_KEYWORD_1.keyword_id;
+      const mockDataWithKeywords = buildMockBookmarksWithKeywords();
       const logMessage = `ApiError: [${status}] ${errorMessage}`;
       vi.mocked(fetch)
-        .mockResolvedValueOnce(new Response(JSON.stringify(mockBookmarks), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify(mockDataWithKeywords), { status: 200 }))
         .mockResolvedValueOnce(new Response(JSON.stringify({ message: errorMessage }), { status }));
 
       const { result } = renderHook(() => useBookmarks());
@@ -119,7 +119,7 @@ describe("useBookmarks - unlinkKeyword", () => {
       });
 
       // Assert
-      expect(result.current.bookmarks.length).toBe(mockBookmarks.length);
+      expect(result.current.bookmarks.length).toBe(mockDataWithKeywords.length);
 
       // Act & Assert
       await expect(result.current.unlinkKeyword(bookmarkId, keywordId)).rejects.toThrow();

--- a/src/app/hooks/useBookmark.unlink.test.tsx
+++ b/src/app/hooks/useBookmark.unlink.test.tsx
@@ -1,9 +1,10 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
-import { useBookmarks } from "./useBookmark";
-import { mockBookmarks } from "../test-utils/bookmarkTestUtils";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
 import { BOOKMARKS_ENDPOINT } from "../constants/apiEndpoints";
+import { mockBookmarks } from "../test-utils/bookmarkTestUtils";
+import { useBookmarks } from "./useBookmark";
 
 global.fetch = vi.fn();
 
@@ -49,35 +50,80 @@ describe("useBookmarks - unlinkKeyword", () => {
     );
   });
 
-  it("should throw an error if unlinking a keyword fails", async () => {
-    // Arrange
-    const bookmarkId = 1;
-    const keywordId = 1;
-    const errorMessage = "Failed to unlink keyword";
-    vi.mocked(fetch)
-      .mockResolvedValueOnce(new Response(JSON.stringify(mockBookmarks), { status: 200 }))
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ message: errorMessage }), { status: 500 })
-      );
+  describe("エラーの出力をテストする", () => {
+    let consoleErrorSpy: MockInstance;
 
-    const { result } = renderHook(() => useBookmarks());
-
-    // Act
-    await act(async () => {
-      await result.current.getBookmarks();
+    beforeEach(() => {
+      // console.errorをスパイして、エラー出力がされるか確認
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    // Assert
-    expect(result.current.bookmarks.length).toBe(mockBookmarks.length);
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
 
-    // Act & Assert
-    await expect(result.current.unlinkKeyword(bookmarkId, keywordId)).rejects.toThrow();
-
-    expect(fetch).toHaveBeenCalledWith(
-      `${BOOKMARKS_ENDPOINT}/${bookmarkId}/keywords/${keywordId}`,
+    const errorTestCase: { description: string; status?: number; errorMessage: string }[] = [
       {
-        method: "DELETE",
-      }
-    );
+        description: "指定されたブックマークとキーワードの関連付けが見つからない",
+        status: 404,
+        errorMessage: "指定されたブックマークに指定されたキーワードが設定されていません。",
+      },
+      {
+        description: "keyword_idが未指定、または空",
+        status: 400,
+        errorMessage: "キーワードを指定してください。",
+      },
+      {
+        description: "bookmark_idが未指定、または空",
+        status: 400,
+        errorMessage: "ブックマークを指定してください。",
+      },
+      {
+        description: "bookmark_idが不正な値",
+        status: 400,
+        errorMessage: "ID は正の整数である必要があります。",
+      },
+      {
+        description: "keyword_idが不正な値",
+        status: 400,
+        errorMessage: "ID は正の整数である必要があります。",
+      },
+      {
+        description: "サーバー内部の予期せぬエラーの場合",
+        status: 500,
+        errorMessage: "サーバー内部でエラーが発生しました。",
+      },
+    ];
+
+    it.each(errorTestCase)("$description", async ({ status, errorMessage }) => {
+      // Arrange
+      const bookmarkId = 1;
+      const keywordId = 1;
+      const logMessage = `ApiError: [${status}] ${errorMessage}`;
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(new Response(JSON.stringify(mockBookmarks), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ message: errorMessage }), { status }));
+
+      const { result } = renderHook(() => useBookmarks());
+
+      // Act
+      await act(async () => {
+        await result.current.getBookmarks();
+      });
+
+      // Assert
+      expect(result.current.bookmarks.length).toBe(mockBookmarks.length);
+
+      // Act & Assert
+      await expect(result.current.unlinkKeyword(bookmarkId, keywordId)).rejects.toThrow();
+
+      expect(fetch).toHaveBeenCalledWith(
+        `${BOOKMARKS_ENDPOINT}/${bookmarkId}/keywords/${keywordId}`,
+        {
+          method: "DELETE",
+        }
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith("キーワードの解除エラー:", logMessage);
+    });
   });
 });


### PR DESCRIPTION
## 概要

ブックマークに紐付いたキーワードを解除する機能を追加しました。

## 変更内容

- `useBookmarks`フックに、キーワードを解除するための`unlinkKeyword`関数を実装しました。
  - この関数は、サーバーに DELETE リクエストを送信し、ブックマークとキーワードの関連付けを削除します。
  - 成功時には、ローカルで管理しているブックマークの状態を更新し、UI に即座に変更が反映されるようにしています。
- `unlinkKeyword`関数の動作を検証するための単体テストを追加しました。