### PR TITLE
refactor(error-handling): ID 検証エラーメッセージの具体化と一貫性の向上

### DIFF
--- a/src/app/api/bookmarks/[bookmark_id]/delete.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/delete.test.ts
@@ -121,7 +121,7 @@ describe("ブックマーク削除APIのテスト (オンメモリDB)", () => {
       {
         description: "不正なIDの場合に400エラーを返す",
         statusCode: HTTP_STATUS_BAD_REQUEST,
-        errorMessage: "IDは正の整数である必要があります。",
+        errorMessage: "無効なブックマークIDです: -1",
         logMessage: "Invalid ID provided: -1. It must be a positive integer.",
         body: "-1",
       },

--- a/src/app/api/bookmarks/[bookmark_id]/get.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/get.test.ts
@@ -71,7 +71,7 @@ describe("ブックマークを1件取得するAPIのテスト", () => {
       {
         description: "不正なIDの場合400エラーを返す",
         statusCode: HTTP_STATUS_BAD_REQUEST,
-        errorMessage: "IDは正の整数である必要があります。",
+        errorMessage: "無効なブックマークIDです: abc",
         logMessage: "Invalid ID provided: abc. It must be a positive integer.",
         body: "abc",
       },

--- a/src/app/api/bookmarks/[bookmark_id]/keywords/[keyword_id]/delete.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/keywords/[keyword_id]/delete.test.ts
@@ -159,25 +159,22 @@ describe("ブックマークに設定されているキーワードの解除テ�
       {
         description: "ブックマークIDが正の整数でない場合、400エラーを返す",
         statusCode: HTTP_STATUS_BAD_REQUEST,
-        errorMessage: "IDは正の整数である必要があります。",
-        logMessage:
-          "Invalid ID provided: 無効なブックマークIDです: abc. It must be a positive integer.",
+        errorMessage: "無効なブックマークIDです: abc",
+        logMessage: "Invalid ID provided: abc. It must be a positive integer.",
         body: { bookmark_id: "abc", keyword_id: "1" },
       },
       {
         description: "keyword_idが数値でない場合、400エラーを返す",
         statusCode: HTTP_STATUS_BAD_REQUEST,
-        errorMessage: "IDは正の整数である必要があります。",
-        logMessage:
-          "Invalid ID provided: 無効なキーワードIDです: abc. It must be a positive integer.",
+        errorMessage: "無効なキーワードIDです: abc",
+        logMessage: "Invalid ID provided: abc. It must be a positive integer.",
         body: { bookmark_id: "1", keyword_id: "abc" },
       },
       {
         description: "keyword_idが負の整数の場合、400エラーを返す",
         statusCode: HTTP_STATUS_BAD_REQUEST,
-        errorMessage: "IDは正の整数である必要があります。",
-        logMessage:
-          "Invalid ID provided: 無効なキーワードIDです: -1. It must be a positive integer.",
+        errorMessage: "無効なキーワードIDです: -1",
+        logMessage: "Invalid ID provided: -1. It must be a positive integer.",
         body: { bookmark_id: "1", keyword_id: "-1" },
       },
       {

--- a/src/app/api/bookmarks/[bookmark_id]/keywords/[keyword_id]/route.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/keywords/[keyword_id]/route.ts
@@ -38,7 +38,7 @@ export async function DELETE(
     return new Response(null, { status: HTTP_STATUS_NO_CONTENT });
   } catch (error: unknown) {
     if (error instanceof InvalidIdError) {
-      return createInvalidIdError({ id: error.invalidId ?? "undefined" });
+      return createInvalidIdError(error);
     }
     if (error instanceof NotExistBookmarkError) {
       return createNoBookmarkError();

--- a/src/app/api/bookmarks/[bookmark_id]/keywords/post.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/keywords/post.test.ts
@@ -150,7 +150,7 @@ describe("POST /api/bookmarks/[bookmark_id]/keywords", () => {
       {
         description: "不正なIDの場合は400エラーを返す",
         statusCode: HTTP_STATUS_BAD_REQUEST,
-        errorMessage: "IDは正の整数である必要があります。",
+        errorMessage: "無効なIDです: abc",
         logMessage: "Invalid ID provided: abc. It must be a positive integer.",
         body: "abc",
       },

--- a/src/app/api/bookmarks/[bookmark_id]/keywords/route.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/keywords/route.ts
@@ -55,7 +55,7 @@ export async function POST(request: Request, params: Promise<{ bookmark_id: stri
     bookmarkId = getId({ id: bookmark_id });
   } catch (error) {
     if (error instanceof InvalidIdError) {
-      return createInvalidIdError({ id: bookmark_id });
+      return createInvalidIdError(error);
     }
     return createInternalError(error);
   }

--- a/src/app/api/bookmarks/[bookmark_id]/put.test.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/put.test.ts
@@ -244,11 +244,7 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
       });
 
       // レスポンスステータスを確認 (400: Bad Request)
-      await assertErrorResponse(
-        response,
-        HTTP_STATUS_BAD_REQUEST,
-        "IDは正の整数である必要があります。"
-      );
+      await assertErrorResponse(response, HTTP_STATUS_BAD_REQUEST, "無効なブックマークIDです: ");
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Invalid ID provided: . It must be a positive integer."
       );
@@ -276,7 +272,7 @@ describe("ブックマーク更新APIのテスト (オンメモリDB)", () => {
       await assertErrorResponse(
         response,
         HTTP_STATUS_BAD_REQUEST,
-        "IDは正の整数である必要があります。"
+        "無効なブックマークIDです: invalid id"
       );
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "Invalid ID provided: invalid id. It must be a positive integer."

--- a/src/app/api/bookmarks/[bookmark_id]/route.ts
+++ b/src/app/api/bookmarks/[bookmark_id]/route.ts
@@ -60,7 +60,7 @@ export async function GET(
     });
   } catch (error: unknown) {
     if (error instanceof InvalidIdError) {
-      return createInvalidIdError({ id: (await params).bookmark_id });
+      return createInvalidIdError(error);
     }
     return createInternalError(error);
   }
@@ -97,7 +97,7 @@ export async function PUT(
       return createDuplicateBookmarkError(bookmark.url);
     }
     if (error instanceof InvalidIdError) {
-      return createInvalidIdError({ id: (await params).bookmark_id });
+      return createInvalidIdError(error);
     }
     return createInternalError(error);
   }
@@ -119,7 +119,7 @@ export async function DELETE(
     return new Response(null, { status: HTTP_STATUS_NO_CONTENT });
   } catch (error: unknown) {
     if (error instanceof InvalidIdError) {
-      return createInvalidIdError({ id: (await params).bookmark_id });
+      return createInvalidIdError(error);
     }
     return createInternalError(error);
   }

--- a/src/app/api/keywords/[keyword_id]/delete.test.ts
+++ b/src/app/api/keywords/[keyword_id]/delete.test.ts
@@ -85,7 +85,7 @@ describe("キーワードDELETE APIのテスト", () => {
         description: "不正なIDを指定した場合",
         keywordId: "abc",
         statusCode: HTTP_STATUS_BAD_REQUEST,
-        errorMessage: "IDは正の整数である必要があります。",
+        errorMessage: "無効なキーワードIDです: abc",
         logMessage: "Invalid ID provided: abc. It must be a positive integer.",
         setup: undefined,
       },

--- a/src/app/api/keywords/[keyword_id]/route.ts
+++ b/src/app/api/keywords/[keyword_id]/route.ts
@@ -24,7 +24,7 @@ export const DELETE = async (
     return new Response(null, { status: HTTP_STATUS_NO_CONTENT });
   } catch (error: unknown) {
     if (error instanceof InvalidIdError) {
-      return createInvalidIdError({ id: (await params).keyword_id });
+      return createInvalidIdError(error);
     }
     return createInternalError(error);
   }

--- a/src/app/api/utils/id.ts
+++ b/src/app/api/utils/id.ts
@@ -12,14 +12,14 @@ export class InvalidIdError extends Error {
 
 export class InvalidBookmarkError extends InvalidIdError {
   constructor(bookmarkId: string | undefined) {
-    super(`無効なブックマークIDです: ${bookmarkId ?? "undefined"}`, bookmarkId);
+    super(bookmarkId, `無効なブックマークIDです: ${bookmarkId ?? "undefined"}`);
     this.name = "InvalidBookmarkError";
   }
 }
 
 export class InvalidKeywordError extends InvalidIdError {
   constructor(keywordId: string | undefined) {
-    super(`無効なキーワードIDです: ${keywordId ?? "undefined"}`, keywordId);
+    super(keywordId, `無効なキーワードIDです: ${keywordId ?? "undefined"}`);
     this.name = "InvalidKeywordError";
   }
 }
@@ -50,7 +50,7 @@ const getIdAsync = async <T extends Error>(
   paramsPromise: Promise<{ [key: string]: string }>,
   key: string,
   NotExistErrorClass: new () => T,
-  InvalidIdErrorClass: new (id: string | undefined) => T
+  InvalidIdErrorClass: new (id: string | undefined, message?: string) => T
 ): Promise<number> => {
   let idValue: string | undefined;
   try {
@@ -62,7 +62,7 @@ const getIdAsync = async <T extends Error>(
     return getId({ id: idValue });
   } catch (error: unknown) {
     if (error instanceof InvalidIdError) {
-      throw new InvalidIdErrorClass(idValue);
+      throw new InvalidIdErrorClass(idValue, error.message);
     }
     throw error;
   }

--- a/src/app/api/utils/response.ts
+++ b/src/app/api/utils/response.ts
@@ -5,6 +5,8 @@ import {
   HTTP_STATUS_NOT_FOUND,
 } from "../../constants/httpStatusCodes";
 
+import { InvalidIdError } from "./id";
+
 const ensureError = (error: unknown): Error =>
   error instanceof Error ? error : new Error(String(error));
 
@@ -29,11 +31,12 @@ export const createErrorResponse = (
 };
 
 // 共通のInvalidIdErrorハンドラー
-export function createInvalidIdError(params: { id: string }) {
+export function createInvalidIdError(error: InvalidIdError) {
+  const errorMessage = error.message || "IDは正の整数である必要があります。";
   return createErrorResponse(
-    "IDは正の整数である必要があります。",
+    errorMessage,
     HTTP_STATUS_BAD_REQUEST,
-    `Invalid ID provided: ${params.id}. It must be a positive integer.`
+    `Invalid ID provided: ${error.invalidId ?? "undefined"}. It must be a positive integer.`
   );
 }
 


### PR DESCRIPTION
## 概要

このプルリクエストは、ID 検証時のエラーハンドリングをリファクタリングし、API から返されるエラーメッセージの具体性と一貫性を向上させるものです。これにより、クライアント側でのデバッグ効率が高まります。

## 変更内容

- **`InvalidIdError`のハンドリング改善:**

  - `createInvalidIdError`関数が、`InvalidIdError`のサブクラス（`InvalidBookmarkError`, `InvalidKeywordError`）を受け取り、より詳細なエラーメッセージ（例：「無効なブックマーク ID です: [ID]」）を生成するように変更しました。

- **コンストラクタ引数の修正:**

  - `InvalidBookmarkError`および`InvalidKeywordError`のコンストラクタで、`invalidId`とメッセージの引数順序を修正し、一貫性を保つようにしました。

- **API ルートの更新:**

  - 上記の変更に伴い、ブックマークとキーワードに関連する API ルート（GET, PUT, DELETE など）を更新し、新しいエラーメッセージ形式を正しく返すようにしました。

- **テストケースの更新:**

  - 関連するテストケースを修正し、更新された具体的なエラーメッセージが返されることを検証するようにしました。

- **`getIdAsync`関数の修正:**
  - `getIdAsync`関数が、`InvalidIdError`から受け取った詳細なエラーメッセージを正しく伝播するように修正しました。

## 期待される効果

- API の利用者が、どの ID が無効であるかを即座に特定できるようになります。
- エラーメッセージの一貫性が向上し、フロントエンドでのエラーハンドリングが容易になります。
- デバッグプロセス全体の効率が向上します。

fixes: [#329](https://github.com/kubotama/linkpage/issues/329), [#330](https://github.com/kubotama/linkpage/issues/330)