### PR TITLE
feat(KeywordTable): ヘッダーとアクションボタンをpropsで設定可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,23 @@ linkpage はリンクデータを SQLite のデータベースで管理します
 
 ## 変更履歴
 
+### 2025/09/17
+
+#### 変更内容
+
+- `KeywordTable`コンポーネントの props を変更しました。
+  - `headerText: string` を必須の prop として追加しました。
+  - `unlinkKeywordClick` prop を削除しました。
+  - 代わりに、`rowActionButton: { label: string, onClick: (id) => void }` を新しい prop として追加しました。
+- 上記の変更に伴い、`BookmarkManager`コンポーネントと関連するテストコードを更新しました。
+
+#### 破壊的変更 (BREAKING CHANGE) ⚠️
+
+このプルリクエストには破壊的変更が含まれます。
+
+- `unlinkKeywordClick` prop は削除されました。代わりに`rowActionButton` prop を使用してください。
+- `headerText` prop が必須になりました。テーブルのヘッダーに表示するテキストを指定する必要があります。
+
 ### 2025/09/13
 
 #### ✨ 新機能

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "3.4.1",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "3.4.1",
+      "version": "4.0.0",
       "dependencies": {
         "better-sqlite3": "^12.2.0",
         "next": "15.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "3.4.1",
+  "version": "4.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/components/BookmarkManager.tsx
+++ b/src/app/components/BookmarkManager.tsx
@@ -107,9 +107,13 @@ export const BookmarkManager = ({ className = "" }: BookmarkManagerProps) => {
               <KeywordTable
                 keywords={selectedBookmark.keywords}
                 className="mt-2 w-keyword-list"
+                headerText="設定されているキーワード"
                 selectedKeywordId={selectedKeywordId}
                 setSelectedKeywordId={setSelectedKeywordId}
-                unlinkKeywordClick={unlinkKeywordClick}
+                rowActionButton={{
+                  label: "解除",
+                  onClick: unlinkKeywordClick,
+                }}
               />
               <fieldset className="mt-5 flex items-end justify-start border-none p-0">
                 <legend className="sr-only">{FIELDSET_KEYWORD_LABEL}</legend>

--- a/src/app/components/KeywordTable.test.tsx
+++ b/src/app/components/KeywordTable.test.tsx
@@ -25,8 +25,12 @@ describe("KeywordTableのテスト", () => {
     const { container } = render(
       <KeywordTable
         keywords={[]}
+        headerText="設定されているキーワード"
         setSelectedKeywordId={mockOnSelectKeyword}
-        unlinkKeywordClick={mockOnUnlinkKeyword}
+        rowActionButton={{
+          label: "解除",
+          onClick: mockOnUnlinkKeyword,
+        }}
       />
     );
     expect(container.firstChild).toBeNull();
@@ -40,8 +44,12 @@ describe("KeywordTableのテスト", () => {
     render(
       <KeywordTable
         keywords={keywords}
+        headerText="設定されているキーワード"
         setSelectedKeywordId={mockOnSelectKeyword}
-        unlinkKeywordClick={mockOnUnlinkKeyword}
+        rowActionButton={{
+          label: "解除",
+          onClick: mockOnUnlinkKeyword,
+        }}
       />
     );
 
@@ -72,12 +80,15 @@ describe("KeywordTableのテスト", () => {
       const keywords = bookmarkToSelect.keywords;
       expect(keywords.length).toBeGreaterThan(0); // Ensure test data is valid
 
-      // prettier-ignore
       render(
         <KeywordTable
           keywords={keywords}
+          headerText="設定されているキーワード"
           setSelectedKeywordId={mockOnSelectKeyword}
-          unlinkKeywordClick={mockOnUnlinkKeyword}
+          rowActionButton={{
+            label: "解除",
+            onClick: mockOnUnlinkKeyword,
+          }}
         />
       );
 
@@ -99,12 +110,15 @@ describe("KeywordTableのテスト", () => {
       const otherKeyword = keywords[1];
 
       render(
-        // prettier-ignore
         <KeywordTable
           keywords={keywords}
+          headerText="設定されているキーワード"
           setSelectedKeywordId={mockOnSelectKeyword}
           selectedKeywordId={selectedKeyword.keyword_id}
-          unlinkKeywordClick={mockOnUnlinkKeyword}
+          rowActionButton={{
+            label: "解除",
+            onClick: mockOnUnlinkKeyword,
+          }}
         />
       );
 
@@ -123,12 +137,15 @@ describe("KeywordTableのテスト", () => {
       const selectedKeyword = keywords[0];
 
       render(
-        // prettier-ignore
         <KeywordTable
           keywords={keywords}
+          headerText="設定されているキーワード"
           setSelectedKeywordId={mockOnSelectKeyword}
           selectedKeywordId={selectedKeyword.keyword_id}
-          unlinkKeywordClick={mockOnUnlinkKeyword}
+          rowActionButton={{
+            label: "解除",
+            onClick: mockOnUnlinkKeyword,
+          }}
         />
       );
 
@@ -160,8 +177,12 @@ describe("KeywordTableのテスト", () => {
       render(
         <KeywordTable
           keywords={keywords}
+          headerText="設定されているキーワード"
           setSelectedKeywordId={mockOnSelectKeyword}
-          unlinkKeywordClick={mockOnUnlinkKeyword}
+          rowActionButton={{
+            label: "解除",
+            onClick: mockOnUnlinkKeyword,
+          }}
         />
       );
 

--- a/src/app/components/KeywordTable.tsx
+++ b/src/app/components/KeywordTable.tsx
@@ -13,17 +13,22 @@ import { ActionButton } from "./ActionButton";
 type KeywordTableProps = {
   keywords?: Keyword[];
   className?: string;
+  headerText: string;
   selectedKeywordId?: number;
   setSelectedKeywordId: (keywordId: number | undefined) => void;
-  unlinkKeywordClick: (keywordId: number) => void;
+  rowActionButton: {
+    label: string;
+    onClick: (keywordId: number) => void;
+  };
 };
 
 export const KeywordTable = ({
   keywords = [],
   className,
+  headerText,
   selectedKeywordId,
   setSelectedKeywordId,
-  unlinkKeywordClick,
+  rowActionButton,
 }: KeywordTableProps): React.ReactElement | null => {
   const { handleSelectKeyword } = useKeywordTable({
     selectedKeywordId,
@@ -38,7 +43,7 @@ export const KeywordTable = ({
     <table aria-label={TABLE_NAME_KEYWORD} className={className}>
       <thead>
         <tr>
-          <th scope="col">キーワード一覧</th>
+          <th scope="col">{headerText}</th>
           <th scope="col" className="sr-only">
             操作
           </th>
@@ -61,9 +66,9 @@ export const KeywordTable = ({
             <td>
               <ActionButton
                 className="w-auto"
-                onClick={() => unlinkKeywordClick(keyword.keyword_id)}
+                onClick={() => rowActionButton.onClick(keyword.keyword_id)}
               >
-                解除
+                {rowActionButton.label}
               </ActionButton>
             </td>
           </tr>


### PR DESCRIPTION
### 概要

`KeywordTable`コンポーネントをリファクタリングし、テーブルヘッダーのテキストと各行のアクションボタンをprops経由でカスタマイズできるようにしました。
これにより、コンポーネントの再利用性が向上し、キーワード以外のリスト表示にも柔軟に対応できるようになります。

### 変更内容

- `KeywordTable`コンポーネントのpropsを変更しました。
  - `headerText: string` を必須のpropとして追加しました。
  - `unlinkKeywordClick` propを削除しました。
  - 代わりに、`rowActionButton: { label: string, onClick: (id) => void }` を新しいpropとして追加しました。
- 上記の変更に伴い、`BookmarkManager`コンポーネントと関連するテストコードを更新しました。

### 破壊的変更 (BREAKING CHANGE) ⚠️

このプルリクエストには破壊的変更が含まれます。

- `unlinkKeywordClick` propは削除されました。代わりに`rowActionButton` propを使用してください。
- `headerText` propが必須になりました。テーブルのヘッダーに表示するテキストを指定する必要があります。

#### 移行例

**旧コード:**
```tsx
<KeywordTable unlinkKeywordClick={handleClick} ... />
```

**新コード:**
```tsx
<KeywordTable
  headerText="見出しテキスト"
  rowActionButton={{ label: "ボタンラベル", onClick: handleClick }}
  ...
/>
```