### PR TITLE
feat(test): テストセットアップを共通化するヘルパー関数を導入

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "4.4.1",
+      "version": "4.4.2",
       "dependencies": {
         "better-sqlite3": "^12.2.0",
         "next": "15.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/src/app/components/BookmarkManager/delete.test.tsx
+++ b/src/app/components/BookmarkManager/delete.test.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { screen, waitFor } from "@testing-library/react";
-import userEvent, { UserEvent } from "@testing-library/user-event";
+import { UserEvent } from "@testing-library/user-event";
 
 import { BOOKMARKS_ENDPOINT } from "../../constants/apiEndpoints";
 import { DELETE_BUTTON_ROLE_NAME } from "../../constants/constants";
@@ -12,7 +12,6 @@ import {
   HTTP_STATUS_INTERNAL_SERVER_ERROR,
   HTTP_STATUS_NO_CONTENT,
   HTTP_STATUS_NOT_FOUND,
-  HTTP_STATUS_OK,
 } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
@@ -20,8 +19,6 @@ import {
   clickButtonByName,
   createMockResponse,
   GOOGLE_BOOKMARK,
-  mockBookmarks,
-  mockKeywords,
   setupBookmarkManagerForTest,
   testApiErrorHandling,
 } from "../../test-utils/bookmarkTestUtils";
@@ -34,21 +31,8 @@ describe("削除ボタン", () => {
 
   beforeEach(async () => {
     global.fetch = mockFetch;
-    mockFetch.mockReset();
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockBookmarks,
-    });
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockKeywords,
-    });
 
-    user = userEvent.setup();
-
-    await setupBookmarkManagerForTest();
+    user = await setupBookmarkManagerForTest({ fetchForSetup: mockFetch });
   });
 
   it("ブックマークが選択されていない場合には削除ボタンは表示されない", () => {

--- a/src/app/components/BookmarkManager/hotkeys.test.tsx
+++ b/src/app/components/BookmarkManager/hotkeys.test.tsx
@@ -3,9 +3,8 @@ import "@testing-library/jest-dom";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { waitFor } from "@testing-library/react";
-import userEvent, { UserEvent } from "@testing-library/user-event";
+import { UserEvent } from "@testing-library/user-event";
 
-import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   assertErrorMessage,
@@ -15,7 +14,6 @@ import {
   GOOGLE_BOOKMARK,
   keyDown,
   mockBookmarks,
-  mockKeywords,
   setBookmarkFormValuesAndClickButton,
   setupBookmarkManagerForTest,
 } from "../../test-utils/bookmarkTestUtils";
@@ -66,25 +64,12 @@ describe("BookmarkManager Hotkeys", () => {
   beforeEach(async () => {
     // Reset mocks before each test
     vi.clearAllMocks();
-    mockFetch.mockReset();
     global.fetch = mockFetch;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockBookmarks,
-    });
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockKeywords,
-    });
 
     // Reset href for window.location mock
     (window.location as MockedLocation).href = "";
 
-    user = userEvent.setup();
-
-    await setupBookmarkManagerForTest();
+    user = await setupBookmarkManagerForTest({ fetchForSetup: mockFetch });
   });
 
   describe("ブックマークが選択されている場合", () => {

--- a/src/app/components/BookmarkManager/keyword.add.test.tsx
+++ b/src/app/components/BookmarkManager/keyword.add.test.tsx
@@ -1,9 +1,9 @@
 import "@testing-library/jest-dom";
 
-import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import { screen, waitFor, within } from "@testing-library/react";
-import userEvent, { UserEvent } from "@testing-library/user-event";
+import { UserEvent } from "@testing-library/user-event";
 
 import { BOOKMARKS_ENDPOINT } from "../../constants/apiEndpoints";
 import {
@@ -17,7 +17,6 @@ import {
   HTTP_STATUS_CONFLICT,
   HTTP_STATUS_FORBIDDEN,
   HTTP_STATUS_INTERNAL_SERVER_ERROR,
-  HTTP_STATUS_OK,
 } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
@@ -27,7 +26,6 @@ import {
   createMockResponse,
   deselectBookmark,
   findBookmarkWithAtLeastNKeywords,
-  mockKeywords,
   setupBookmarkManagerForTest,
   testApiErrorHandling,
   typeInTextbox,
@@ -67,25 +65,17 @@ describe("選択されたブックマークにキーワードを追加", () => {
   let user: UserEvent;
   let bookmarkToSelect: Bookmark;
 
-  beforeEach(async () => {
-    mockFetch.mockReset();
+  beforeAll(() => {
+    mockBookmarksWithKeywords = buildMockBookmarksWithKeywords();
+  });
 
+  beforeEach(async () => {
     global.fetch = mockFetch;
 
-    mockBookmarksWithKeywords = buildMockBookmarksWithKeywords();
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockBookmarksWithKeywords,
+    user = await setupBookmarkManagerForTest({
+      fetchForSetup: mockFetch,
+      bookmarksForSetup: mockBookmarksWithKeywords,
     });
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockKeywords,
-    });
-    user = userEvent.setup();
-
-    await setupBookmarkManagerForTest();
   });
 
   afterEach(() => {

--- a/src/app/components/BookmarkManager/keyword.view.test.tsx
+++ b/src/app/components/BookmarkManager/keyword.view.test.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { screen, within } from "@testing-library/react";
-import userEvent, { UserEvent } from "@testing-library/user-event";
+import { UserEvent } from "@testing-library/user-event";
 
 import {
   ADD_BUTTON_ROLE_NAME,
@@ -12,13 +12,11 @@ import {
   TABLE_NAME_LINKED_KEYWORD,
   UNLINK_BUTTON_ROLE_NAME,
 } from "../../constants/constants";
-import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   buildMockBookmarksWithKeywords,
   clickBookmark,
   findBookmarkWithAtLeastNKeywords,
-  mockKeywords,
   setupBookmarkManagerForTest,
 } from "../../test-utils/bookmarkTestUtils";
 import { Bookmark } from "../../types/Bookmark";
@@ -34,21 +32,12 @@ describe("キーワード詳細フォームの表示のテスト", () => {
   });
 
   beforeEach(async () => {
-    mockFetch.mockReset();
     global.fetch = mockFetch;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockBookmarksWithKeywords,
-    });
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockKeywords,
-    });
-    user = userEvent.setup();
 
-    await setupBookmarkManagerForTest();
+    user = await setupBookmarkManagerForTest({
+      fetchForSetup: mockFetch,
+      bookmarksForSetup: mockBookmarksWithKeywords,
+    });
   });
 
   describe("ブックマークが選択されていない場合", () => {

--- a/src/app/components/BookmarkManager/open.test.tsx
+++ b/src/app/components/BookmarkManager/open.test.tsx
@@ -3,16 +3,13 @@ import "@testing-library/jest-dom";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { waitFor } from "@testing-library/react";
-import userEvent, { UserEvent } from "@testing-library/user-event";
+import { UserEvent } from "@testing-library/user-event";
 
-import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   assertErrorMessage,
   clickBookmark,
   GOOGLE_BOOKMARK,
-  mockBookmarks,
-  mockKeywords,
   setBookmarkFormValuesAndEnterKeydown,
   setupBookmarkManagerForTest,
 } from "../../test-utils/bookmarkTestUtils";
@@ -66,26 +63,13 @@ describe("「開く」ボタン: 入力されたURLを新しいタブで開く",
 
   beforeEach(async () => {
     // 各テスト前にモックをリセット
-    // jest.clearAllMocks();
-    vi.clearAllMocks();
     global.fetch = mockFetch;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockBookmarks,
-    });
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockKeywords,
-    });
+    vi.clearAllMocks();
 
     // hrefをリセット
     (window.location as MockedLocation).href = "";
 
-    user = userEvent.setup();
-
-    await setupBookmarkManagerForTest();
+    user = await setupBookmarkManagerForTest({ fetchForSetup: mockFetch });
   });
 
   describe("ブックマーク選択後", () => {

--- a/src/app/components/BookmarkManager/parameter.test.tsx
+++ b/src/app/components/BookmarkManager/parameter.test.tsx
@@ -2,17 +2,14 @@ import "@testing-library/jest-dom";
 
 import { beforeEach, describe, it, vi } from "vitest";
 
-import userEvent, { UserEvent } from "@testing-library/user-event";
+import { UserEvent } from "@testing-library/user-event";
 
 import { PARAMETER_BUTTON_ROLE_NAME } from "../../constants/constants";
-import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   clickBookmark,
   expectBookmarkFormValues,
   GOOGLE_BOOKMARK,
-  mockBookmarks,
-  mockKeywords,
   setBookmarkFormValuesAndClickButton,
   setupBookmarkManagerForTest,
 } from "../../test-utils/bookmarkTestUtils";
@@ -24,22 +21,9 @@ describe("「パラメータ」ボタン: URLから無駄な文字列を削除�
 
   describe("#や?の後ろを削除する", () => {
     beforeEach(async () => {
-      mockFetch.mockReset();
       global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: HTTP_STATUS_OK,
-        json: async () => mockBookmarks,
-      });
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: HTTP_STATUS_OK,
-        json: async () => mockKeywords,
-      });
 
-      user = userEvent.setup();
-
-      await setupBookmarkManagerForTest();
+      user = await setupBookmarkManagerForTest({ fetchForSetup: mockFetch });
 
       const bookmarkToSelect = GOOGLE_BOOKMARK; // Google
       await clickBookmark(user, bookmarkToSelect);

--- a/src/app/components/BookmarkManager/path.test.tsx
+++ b/src/app/components/BookmarkManager/path.test.tsx
@@ -2,17 +2,14 @@ import "@testing-library/jest-dom";
 
 import { beforeEach, describe, it, vi } from "vitest";
 
-import userEvent, { UserEvent } from "@testing-library/user-event";
+import { UserEvent } from "@testing-library/user-event";
 
 import { ARROW_BUTTON_ROLE_NAME } from "../../constants/constants";
-import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   clickBookmark,
   expectBookmarkFormValues,
   GOOGLE_BOOKMARK,
-  mockBookmarks,
-  mockKeywords,
   setBookmarkFormValuesAndClickButton,
   setupBookmarkManagerForTest,
 } from "../../test-utils/bookmarkTestUtils";
@@ -23,22 +20,9 @@ describe("「←」ボタン", () => {
   let user: UserEvent;
 
   beforeEach(async () => {
-    mockFetch.mockReset();
     global.fetch = mockFetch;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockBookmarks,
-    });
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockKeywords,
-    });
 
-    user = userEvent.setup();
-
-    await setupBookmarkManagerForTest();
+    user = await setupBookmarkManagerForTest({ fetchForSetup: mockFetch });
 
     await clickBookmark(user, GOOGLE_BOOKMARK);
     await assertBookmarkIsSelected(GOOGLE_BOOKMARK);

--- a/src/app/components/BookmarkManager/select.test.tsx
+++ b/src/app/components/BookmarkManager/select.test.tsx
@@ -2,9 +2,8 @@ import "@testing-library/jest-dom";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import userEvent, { UserEvent } from "@testing-library/user-event";
+import { UserEvent } from "@testing-library/user-event";
 
-import { HTTP_STATUS_OK } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
   assertNoBookmarkIsSelected,
@@ -12,8 +11,6 @@ import {
   createBookmark,
   deselectBookmark,
   GOOGLE_BOOKMARK,
-  mockBookmarks,
-  mockKeywords,
   setupBookmarkManagerForTest,
 } from "../../test-utils/bookmarkTestUtils";
 import { Bookmark } from "../../types/Bookmark";
@@ -24,21 +21,9 @@ describe("ブックマークの選択", () => {
   let user: UserEvent;
 
   beforeEach(async () => {
-    mockFetch.mockReset();
     global.fetch = mockFetch;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockBookmarks,
-    });
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockKeywords,
-    });
-    user = userEvent.setup();
 
-    await setupBookmarkManagerForTest();
+    user = await setupBookmarkManagerForTest({ fetchForSetup: mockFetch });
   });
 
   it("初期状態では、URLとタイトルのテキストボックスには、なにも表示されていない。選択解除のボタンが表示されていない。", async () => {

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom";
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
 import { screen, waitFor, within } from "@testing-library/react";
-import userEvent, { UserEvent } from "@testing-library/user-event";
+import { UserEvent } from "@testing-library/user-event";
 
 import { BOOKMARKS_ENDPOINT } from "../../constants/apiEndpoints";
 import { TABLE_NAME_BOOKMARKS, UPDATE_BUTTON_ROLE_NAME } from "../../constants/constants";
@@ -13,7 +13,6 @@ import {
   HTTP_STATUS_INTERNAL_SERVER_ERROR,
   HTTP_STATUS_NO_CONTENT,
   HTTP_STATUS_NOT_FOUND,
-  HTTP_STATUS_OK,
 } from "../../constants/httpStatusCodes";
 import {
   assertBookmarkIsSelected,
@@ -25,8 +24,6 @@ import {
   expectBookmarkFormValues,
   GMAIL_BOOKMARK,
   GOOGLE_BOOKMARK,
-  mockBookmarks,
-  mockKeywords,
   setBookmarkFormValuesAndClickButton,
   setupBookmarkManagerForTest,
   testApiErrorHandling,
@@ -39,21 +36,9 @@ describe("タイトルの更新ボタン", () => {
   let user: UserEvent;
 
   beforeEach(async () => {
-    mockFetch.mockReset();
     global.fetch = mockFetch;
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockBookmarks,
-    });
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: HTTP_STATUS_OK,
-      json: async () => mockKeywords,
-    });
-    user = userEvent.setup();
 
-    await setupBookmarkManagerForTest();
+    user = await setupBookmarkManagerForTest({ fetchForSetup: mockFetch });
   });
 
   it("ブックマークが選択されていない場合には、タイトルの更新ボタンは表示されない。", () => {

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -1,7 +1,7 @@
 import { expect, MockInstance } from "vitest";
 
 import { render, screen, waitFor, within } from "@testing-library/react";
-import { UserEvent } from "@testing-library/user-event";
+import userEvent, { UserEvent } from "@testing-library/user-event";
 
 import { BookmarkManager } from "../components/BookmarkManager";
 import {
@@ -292,12 +292,34 @@ export const setBookmarkFormValuesAndEnterKeydown = async (user: UserEvent, url:
   await keyDown(user, "{enter}");
 };
 
+type setupBookmarkManagerForTestProps = {
+  fetchForSetup: MockInstance;
+  bookmarksForSetup?: Bookmark[];
+  keywordsForSetup?: Keyword[];
+};
+
 /**
  * BookmarkManagerコンポーネントをレンダリングし、初期データがロードされるのを待つ
  */
-export const setupBookmarkManagerForTest = async () => {
+export const setupBookmarkManagerForTest = async ({
+  fetchForSetup,
+  bookmarksForSetup = mockBookmarks,
+  keywordsForSetup = mockKeywords,
+}: setupBookmarkManagerForTestProps) => {
+  fetchForSetup.mockReset();
+  fetchForSetup.mockResolvedValueOnce({
+    ok: true,
+    status: HTTP_STATUS_OK,
+    json: async () => bookmarksForSetup,
+  });
+  fetchForSetup.mockResolvedValueOnce({
+    ok: true,
+    status: HTTP_STATUS_OK,
+    json: async () => keywordsForSetup,
+  });
   render(<BookmarkManager />);
   await screen.findByRole("cell", { name: LINKPAGE_BOOKMARK.title });
+  return userEvent.setup();
 };
 
 export const deselectBookmark = async (user: UserEvent) => {


### PR DESCRIPTION
## 概要

`BookmarkManager`コンポーネントのテストコードにおいて、セットアップ処理の重複を解消し、可読性と保守性を向上させるためのリファクタリングを実施しました。

## 変更内容

各テストファイル内の `beforeEach` フックで繰り返されていた、以下の定型的な処理を新しいヘルパー関数 `setupBookmarkManagerForTest` に集約しました。

- `mockFetch` のセットアップとリセット
- `BookmarkManager` コンポーネントのレンダリング
- `userEvent` の初期化
- 初期データの読み込み完了待機

このヘルパー関数を `src/app/test-utils/bookmarkTestUtils.tsx` に追加し、関連するすべてのテストファイル (`src/app/components/BookmarkManager/*.test.tsx`) で利用するように修正しました。

## 変更による効果

- **DRY原則の徹底**: セットアップロジックの重複を排除し、コードが簡潔になりました。
- **可読性の向上**: 各テストの `beforeEach` がシンプルになり、テストの本来の意図がより明確になりました。
- **保守性の向上**: セットアップ処理の仕様変更が必要になった場合、`setupBookmarkManagerForTest` 関数を修正するだけで、すべてのテストに一括で反映できます。

## 影響範囲

- `src/app/test-utils/bookmarkTestUtils.tsx`
- `src/app/components/BookmarkManager/delete.test.tsx`
- `src/app/components/BookmarkManager/hotkeys.test.tsx`
- `src/app/components/BookmarkManager/keyword.view.test.tsx`
- `src/app/components/BookmarkManager/open.test.tsx`
- `src/app/components/BookmarkManager/parameter.test.tsx`
- `src/app/components/BookmarkManager/path.test.tsx`
- `src/app/components/BookmarkManager/select.test.tsx`
- `src/app/components/BookmarkManager/update.test.tsx`