### PR TITLE
feat(keyword): 設定済みキーワードテーブルをフォーム外に移動しUIを改善

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dependencies": {
         "better-sqlite3": "^12.2.0",
         "next": "15.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/src/app/components/BookmarkManager.tsx
+++ b/src/app/components/BookmarkManager.tsx
@@ -133,18 +133,6 @@ export const BookmarkManager = ({ className = "" }: BookmarkManagerProps) => {
                   onChange={(e) => setTextTitle(e.target.value)}
                 />
               </div>
-              <KeywordTable
-                keywords={selectedKeywords}
-                className="mt-2 w-keyword-list"
-                labelText={TABLE_NAME_LINKED_KEYWORD}
-                headerText={TABLE_HEADER_LINKED_KEYWORD}
-                selectedKeywordId={selectedKeywordId}
-                setSelectedKeywordId={setSelectedKeywordId}
-                rowActionButton={{
-                  label: UNLINK_BUTTON_ROLE_NAME,
-                  onClick: unlinkKeywordClick,
-                }}
-              />
               <fieldset className="mt-5 flex items-end justify-start border-none p-0">
                 <legend className="sr-only">{FIELDSET_KEYWORD_LABEL}</legend>
                 <BookmarkInputField
@@ -162,6 +150,20 @@ export const BookmarkManager = ({ className = "" }: BookmarkManagerProps) => {
                 </div>
               </fieldset>
             </form>
+          )}
+          {selectedBookmark && (
+            <KeywordTable
+              keywords={selectedKeywords}
+              className="mt-4 w-keyword-list"
+              labelText={TABLE_NAME_LINKED_KEYWORD}
+              headerText={TABLE_HEADER_LINKED_KEYWORD}
+              selectedKeywordId={selectedKeywordId}
+              setSelectedKeywordId={setSelectedKeywordId}
+              rowActionButton={{
+                label: UNLINK_BUTTON_ROLE_NAME,
+                onClick: unlinkKeywordClick,
+              }}
+            />
           )}
           <KeywordTable
             keywords={availableKeywords}

--- a/src/app/constants/constants.ts
+++ b/src/app/constants/constants.ts
@@ -15,7 +15,7 @@ export const ADD_BUTTON_ROLE_NAME = "追加";
 export const TABLE_NAME_LINKED_KEYWORD = "設定されたキーワードのテーブル";
 export const TABLE_NAME_ALL_KEYWORD = "すべてのキーワードのテーブル";
 export const TABLE_HEADER_LINKED_KEYWORD = "設定されているキーワード";
-export const TABLE_HEADER_ALL_KEYWORD = "すべてのキーワード";
+export const TABLE_HEADER_ALL_KEYWORD = "設定されていないキーワード";
 
 export const TABLE_NAME_BOOKMARKS = "ブックマークのテーブル";
 


### PR DESCRIPTION
## 概要

ブックマーク詳細フォームのUIを改善し、コンポーネントの責務をより明確にしました。具体的には、選択中のブックマークに設定されているキーワードを表示するテーブルを、ブックマーク編集フォームの外側に移動しました。

また、利用可能なキーワード一覧のテーブルヘッダーを「すべてのキーワード」から「設定されていないキーワード」に修正し、テーブルの内容がより直感的に理解できるよう改善しました。

## 変更点

- **UIの改善**:
  - 設定済みキーワードテーブル (`KeywordTable`) をブックマーク詳細フォーム (`<form>`) の外に移動しました。これにより、フォームはブックマーク情報の編集と新規キーワードの追加という責務に集中します。
- **テキストの修正**:
  - `constants.ts` 内の `TABLE_HEADER_ALL_KEYWORD` を「設定されていないキーワード」に更新し、UI上の表記をより正確にしました。

## 影響範囲

この変更はUIのレイアウトとテキストに関するものであり、既存の機能（キーワードの設定・解除など）の動作に影響はありません。

## 確認方法

1.  いずれかのブックマークを選択します。
2.  ブックマーク詳細エリアに、URL・タイトル等の編集フォームが表示されることを確認します。
3.  フォームの下に「設定されているキーワード」テーブルと「設定されていないキーワード」テーブルが表示されることを確認します。
4.  キーワードの設定・解除がこれまで通り行えることを確認します。

fixes: #356 