### PR TITLE
# feat(bookmark): ブックマーク選択時にキーワードの選択状態を維持

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ linkpage はリンクデータを SQLite のデータベースで管理します
 
 ### ✨ feat: 2025/09/22 ブックマークの選択時にキーワードの選択を維持
 
-## 変更内容
+#### 変更内容
 
 - `useBookmarkTable` フックの `handleSelectBookmark` 関数から、キーワード選択を解除する `setSelectedKeywordId(undefined)` の呼び出しを削除しました。
 - 上記の変更に伴い、`BookmarkTable` コンポーネントおよび関連するフックから、不要になった `setSelectedKeywordId` プロパティを削除しました。

--- a/README.md
+++ b/README.md
@@ -442,6 +442,14 @@ linkpage はリンクデータを SQLite のデータベースで管理します
 
 ## 変更履歴
 
+### ✨ feat: 2025/09/22 ブックマークの選択時にキーワードの選択を維持
+
+## 変更内容
+
+- `useBookmarkTable` フックの `handleSelectBookmark` 関数から、キーワード選択を解除する `setSelectedKeywordId(undefined)` の呼び出しを削除しました。
+- 上記の変更に伴い、`BookmarkTable` コンポーネントおよび関連するフックから、不要になった `setSelectedKeywordId` プロパティを削除しました。
+- `useBookmarkManager` の `Escape` キーハンドラから `setSelectedKeywordId` の呼び出しを削除し、ブックマークの選択解除のみが行われるように修正しました。
+
 ### ✨ feat: 2025/09/21 キーワード紐付け機能
 
 #### ✨ 新機能

--- a/README.md
+++ b/README.md
@@ -446,8 +446,7 @@ linkpage はリンクデータを SQLite のデータベースで管理します
 
 #### 変更内容
 
-- `useBookmarkTable` フックの `handleSelectBookmark` 関数から、キーワード選択を解除する `setSelectedKeywordId(undefined)` の呼び出しを削除しました。
-- 上記の変更に伴い、`BookmarkTable` コンポーネントおよび関連するフックから、不要になった `setSelectedKeywordId` プロパティを削除しました。
+- キーワードでブックマークを絞り込んだ後、別のブックマークを選択しても絞り込み状態が維持されるようになりました。
 
 ### ✨ feat: 2025/09/21 キーワード紐付け機能
 

--- a/README.md
+++ b/README.md
@@ -448,7 +448,6 @@ linkpage はリンクデータを SQLite のデータベースで管理します
 
 - `useBookmarkTable` フックの `handleSelectBookmark` 関数から、キーワード選択を解除する `setSelectedKeywordId(undefined)` の呼び出しを削除しました。
 - 上記の変更に伴い、`BookmarkTable` コンポーネントおよび関連するフックから、不要になった `setSelectedKeywordId` プロパティを削除しました。
-- `useBookmarkManager` の `Escape` キーハンドラから `setSelectedKeywordId` の呼び出しを削除し、ブックマークの選択解除のみが行われるように修正しました。
 
 ### ✨ feat: 2025/09/21 キーワード紐付け機能
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "5.0.1",
+      "version": "5.1.0",
       "dependencies": {
         "better-sqlite3": "^12.2.0",
         "next": "15.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/src/app/components/BookmarkManager.tsx
+++ b/src/app/components/BookmarkManager.tsx
@@ -97,7 +97,6 @@ export const BookmarkManager = ({ className = "" }: BookmarkManagerProps) => {
           selectedBookmarkId={selectedBookmarkId}
           onSelectBookmarkId={setSelectedBookmarkId}
           selectedKeywordId={selectedKeywordId}
-          setSelectedKeywordId={setSelectedKeywordId}
           className="w-bookmark-list"
         />
         <div className="w-bookmark-details">

--- a/src/app/components/BookmarkTable.test.tsx
+++ b/src/app/components/BookmarkTable.test.tsx
@@ -19,11 +19,9 @@ import { BookmarkTable } from "./BookmarkTable";
 
 describe("BookmarkTableのテスト", () => {
   let mockOnSelectBookmark = vi.fn<(bookmarkId: number) => void>();
-  let mockSetSelectedKeywordId = vi.fn();
 
   beforeEach(() => {
     mockOnSelectBookmark = vi.fn();
-    mockSetSelectedKeywordId = vi.fn();
   });
 
   const renderComponent = (props = {}, customBookmarks = mockBookmarks) => {
@@ -33,7 +31,6 @@ describe("BookmarkTableのテスト", () => {
         selectedBookmarkId={undefined}
         onSelectBookmarkId={mockOnSelectBookmark}
         selectedKeywordId={undefined}
-        setSelectedKeywordId={mockSetSelectedKeywordId}
         {...props}
       />
     );

--- a/src/app/components/BookmarkTable.tsx
+++ b/src/app/components/BookmarkTable.tsx
@@ -9,7 +9,6 @@ type BookmarkTableProps = {
   selectedBookmarkId: number | undefined;
   onSelectBookmarkId: (bookmarkId: number) => void;
   selectedKeywordId: number | undefined;
-  setSelectedKeywordId: (keywordId: number | undefined) => void;
   className?: string;
 };
 
@@ -18,7 +17,6 @@ export const BookmarkTable = ({
   selectedBookmarkId,
   onSelectBookmarkId,
   selectedKeywordId,
-  setSelectedKeywordId,
   className = "",
 }: BookmarkTableProps): React.ReactElement => {
   const { bookmarkRows, handleSelectBookmark } = useBookmarkTable({
@@ -26,7 +24,6 @@ export const BookmarkTable = ({
     selectedBookmarkId,
     selectedKeywordId,
     onSelectBookmarkId,
-    setSelectedKeywordId,
   });
 
   return (

--- a/src/app/hooks/useBookmarkTable.ts
+++ b/src/app/hooks/useBookmarkTable.ts
@@ -22,7 +22,6 @@ type UseBookmarkTableProps = {
   selectedBookmarkId: number | undefined;
   selectedKeywordId: number | undefined;
   onSelectBookmarkId: (bookmarkId: number) => void;
-  setSelectedKeywordId: (keywordId: number | undefined) => void;
 };
 
 export const useBookmarkTable = ({
@@ -30,14 +29,12 @@ export const useBookmarkTable = ({
   selectedBookmarkId,
   selectedKeywordId,
   onSelectBookmarkId,
-  setSelectedKeywordId,
 }: UseBookmarkTableProps) => {
   const handleSelectBookmark = useCallback(
     (bookmarkId: number) => {
       onSelectBookmarkId(bookmarkId);
-      setSelectedKeywordId(undefined);
     },
-    [onSelectBookmarkId, setSelectedKeywordId]
+    [onSelectBookmarkId]
   );
 
   const bookmarkRows: BookmarkRow[] = useMemo(() => {


### PR DESCRIPTION
## 概要

ブックマークテーブルでブックマークが選択された際に、キーワードテーブルで選択されていたキーワードの選択状態が解除されないように変更しました。

これにより、ユーザーがキーワードでブックマークを絞り込んだ後、別のブックマークをクリックしても絞り込み状態が維持され、UIの一貫性と操作性が向上します。

## 変更内容

- `useBookmarkTable` フックの `handleSelectBookmark` 関数から、キーワード選択を解除する `setSelectedKeywordId(undefined)` の呼び出しを削除しました。
- 上記の変更に伴い、`BookmarkTable` コンポーネントおよび関連するフックから、不要になった `setSelectedKeywordId` プロパティを削除しました。

## 影響範囲

- ブックマーク一覧 (`BookmarkTable`)
- ブックマーク管理フック (`useBookmarkManager`, `useBookmarkTable`)

この変更はUIの挙動を改善するものであり、既存のAPIやデータ構造への影響はありません。

fixes #359 