### PR TITLE
feat(hooks): `addKeyword` の重複登録防止とテスト拡充

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "dependencies": {
         "better-sqlite3": "^12.2.0",
         "next": "15.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/src/app/hooks/useBookmark.addKeyword.test.ts
+++ b/src/app/hooks/useBookmark.addKeyword.test.ts
@@ -4,6 +4,12 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 
 import { BOOKMARKS_ENDPOINT } from "../constants/apiEndpoints";
 import {
+  HTTP_STATUS_CONFLICT,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_NOT_FOUND,
+  HTTP_STATUS_OK,
+} from "../constants/httpStatusCodes";
+import {
   buildMockBookmarksWithKeywords,
   createMockResponse,
   findBookmarkWithAtLeastNKeywords,
@@ -21,9 +27,11 @@ describe("useBookmarks - addKeyword", () => {
     mockFetch.mockClear();
     const mockDataWithKeywords = buildMockBookmarksWithKeywords();
     mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify(mockDataWithKeywords), { status: 200 })
+      new Response(JSON.stringify(mockDataWithKeywords), { status: HTTP_STATUS_OK })
     );
-    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(mockKeywords), { status: 200 }));
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(mockKeywords), { status: HTTP_STATUS_OK })
+    );
   });
 
   afterEach(() => {
@@ -177,18 +185,17 @@ describe("useBookmarks - addKeyword", () => {
     const errorTestCases: { description: string; status: number; errorMessage: string }[] = [
       {
         description: "指定されたブックマークが見つからない (404)",
-        status: 404,
+        status: HTTP_STATUS_NOT_FOUND,
         errorMessage: "指定されたブックマークがありません。",
       },
       {
         description: "キーワードが既に登録済み (409)",
-        status: 409,
+        status: HTTP_STATUS_CONFLICT,
         errorMessage: "指定されたキーワードは既にこのブックマークに登録されています。",
       },
-      // ... 他のエラーケース
       {
         description: "サーバー内部エラー (500)",
-        status: 500,
+        status: HTTP_STATUS_INTERNAL_SERVER_ERROR,
         errorMessage: "サーバー内部でエラーが発生しました。",
       },
     ];

--- a/src/app/hooks/useBookmark.addKeyword.test.ts
+++ b/src/app/hooks/useBookmark.addKeyword.test.ts
@@ -18,6 +18,26 @@ import {
 } from "../test-utils/bookmarkTestUtils";
 import { useBookmarks } from "./useBookmark";
 
+const assertAddKeywordApiCall = async (bookmarkId: number, keywordName: string) => {
+  await waitFor(() => {
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${BOOKMARKS_ENDPOINT}/${bookmarkId}/keywords`,
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ keyword_name: keywordName }),
+      })
+    );
+  });
+};
+
+const assertBookmarkUpdatedWithKeyword = (bookmarkId: number, keywordName: string) => {
+  const updatedBookmark = result.current.bookmarks.find((b) => b.bookmark_id === bookmarkId);
+  expect(updatedBookmark?.keywords.some((k) => k.keyword_name === keywordName)).toBe(true);
+};
+
 const mockFetch = vi.fn();
 let result: { current: ReturnType<typeof useBookmarks> };
 
@@ -82,20 +102,7 @@ describe("useBookmarks - addKeyword", () => {
       });
 
       // Assert
-      await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith(
-          `${BOOKMARKS_ENDPOINT}/${bookmarkToSelect.bookmark_id}/keywords`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              keyword_name: UNREGISTERED_KEYWORD,
-            }),
-          }
-        );
-      });
+      await assertAddKeywordApiCall(bookmarkToSelect.bookmark_id, UNREGISTERED_KEYWORD);
 
       const afterKeywords = result.current.keywords;
       expect(afterKeywords).toHaveLength(mockKeywords.length + 1);
@@ -103,12 +110,7 @@ describe("useBookmarks - addKeyword", () => {
       expect(addedKeyword.keyword_name).toBe(UNREGISTERED_KEYWORD);
       expect(addedKeyword.keyword_id).toBe(newKeywordId);
       // ブックマークの状態も更新されていることを確認
-      const updatedBookmark = result.current.bookmarks.find(
-        (b) => b.bookmark_id === bookmarkToSelect.bookmark_id
-      );
-      expect(updatedBookmark?.keywords.some((k) => k.keyword_name === UNREGISTERED_KEYWORD)).toBe(
-        true
-      );
+      assertBookmarkUpdatedWithKeyword(bookmarkToSelect.bookmark_id, UNREGISTERED_KEYWORD);
     });
 
     it("登録済みのキーワードを設定する", async () => {
@@ -142,32 +144,15 @@ describe("useBookmarks - addKeyword", () => {
       });
 
       // Assert
-      await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith(
-          `${BOOKMARKS_ENDPOINT}/${bookmarkToSelect.bookmark_id}/keywords`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              keyword_name: NOLINKED_KEYWORD.keyword_name,
-            }),
-          }
-        );
-      });
+      await assertAddKeywordApiCall(bookmarkToSelect.bookmark_id, NOLINKED_KEYWORD.keyword_name);
+
       const afterKeywords = result.current.keywords;
       expect(afterKeywords).toHaveLength(mockKeywords.length);
       expect(afterKeywords.some((k) => k.keyword_name === NOLINKED_KEYWORD.keyword_name)).toBe(
         true
       );
       // ブックマークの状態も更新されていることを確認
-      const updatedBookmark = result.current.bookmarks.find(
-        (b) => b.bookmark_id === bookmarkToSelect.bookmark_id
-      );
-      expect(
-        updatedBookmark?.keywords.some((k) => k.keyword_name === NOLINKED_KEYWORD.keyword_name)
-      ).toBe(true);
+      assertBookmarkUpdatedWithKeyword(bookmarkToSelect.bookmark_id, NOLINKED_KEYWORD.keyword_name);
     });
   });
 
@@ -217,25 +202,11 @@ describe("useBookmarks - addKeyword", () => {
       ).rejects.toThrow();
 
       // Assert
-      await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledTimes(1);
-        expect(mockFetch).toHaveBeenCalledWith(
-          `${BOOKMARKS_ENDPOINT}/${bookmarkToSelect.bookmark_id}/keywords`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              keyword_name: NOLINKED_KEYWORD.keyword_name,
-            }),
-          }
-        );
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-          "キーワードの追加エラー:",
-          expect.stringContaining(errorMessage)
-        );
-      });
+      assertAddKeywordApiCall(bookmarkToSelect.bookmark_id, NOLINKED_KEYWORD.keyword_name);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "キーワードの追加エラー:",
+        expect.stringContaining(errorMessage)
+      );
     });
   });
 });

--- a/src/app/hooks/useBookmark.addKeyword.test.ts
+++ b/src/app/hooks/useBookmark.addKeyword.test.ts
@@ -1,14 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
 
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 
+import { BOOKMARKS_ENDPOINT } from "../constants/apiEndpoints";
 import {
   buildMockBookmarksWithKeywords,
   createMockResponse,
+  findBookmarkWithAtLeastNKeywords,
   GOOGLE_BOOKMARK,
   mockKeywords,
+  NOLINKED_KEYWORD,
 } from "../test-utils/bookmarkTestUtils";
-
 import { useBookmarks } from "./useBookmark";
 
 const mockFetch = vi.fn();
@@ -33,6 +35,7 @@ describe("useBookmarks - addKeyword", () => {
 
     it("未登録のキーワードを追加する", async () => {
       // Arrange
+
       const newKeywordId = 99;
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
@@ -46,25 +49,118 @@ describe("useBookmarks - addKeyword", () => {
         await result.current.getBookmarks();
         await result.current.getKeywords();
       });
+      const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(result.current.bookmarks, 0); // キーワードが0個のブックマークを選択
 
       // Actの前の状態を確認
+      // 登録されているキーワードはテスト用のデータ
       expect(result.current.keywords).toEqual(mockKeywords);
+      // 設定するキーワードはキーワードとして未登録
       expect(result.current.keywords.some((k) => k.keyword_name === UNREGISTERED_KEYWORD)).toBe(
         false
       );
+      // 設定するブックマークにはキーワードとして登録されていない
+      expect(GOOGLE_BOOKMARK.keywords.some((k) => k.keyword_name === UNREGISTERED_KEYWORD)).toBe(
+        false
+      );
+
       // Act
       await act(async () => {
-        await result.current.addKeyword(GOOGLE_BOOKMARK.bookmark_id, UNREGISTERED_KEYWORD);
+        await result.current.addKeyword(bookmarkToSelect.bookmark_id, UNREGISTERED_KEYWORD);
       });
 
       // Assert
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${BOOKMARKS_ENDPOINT}/${bookmarkToSelect.bookmark_id}/keywords`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              keyword_name: UNREGISTERED_KEYWORD,
+            }),
+          }
+        );
+      });
+
       const afterKeywords = result.current.keywords;
       expect(afterKeywords).toHaveLength(mockKeywords.length + 1);
       const addedKeyword = afterKeywords[afterKeywords.length - 1];
-      expect(addedKeyword.keyword_name).toBe("未登録のキーワード");
+      expect(addedKeyword.keyword_name).toBe(UNREGISTERED_KEYWORD);
       expect(addedKeyword.keyword_id).toBe(newKeywordId);
+      // ブックマークの状態も更新されていることを確認
+      const updatedBookmark = result.current.bookmarks.find(
+        (b) => b.bookmark_id === bookmarkToSelect.bookmark_id
+      );
+      expect(updatedBookmark?.keywords.some((k) => k.keyword_name === UNREGISTERED_KEYWORD)).toBe(
+        true
+      );
     });
-    it("登録済みのキーワードを設定する", () => {});
+
+    it("登録済みのキーワードを設定する", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          message: "キーワードをブックマークに追加しました。",
+          keyword_name: NOLINKED_KEYWORD.keyword_name,
+          keyword_id: NOLINKED_KEYWORD.keyword_id,
+        })
+      );
+      const { result } = renderHook(() => useBookmarks());
+      await act(async () => {
+        await result.current.getBookmarks();
+        await result.current.getKeywords();
+      });
+      const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(result.current.bookmarks, 0); // キーワードが0個のブックマークを選択
+
+      // Actの前の状態を確認
+      // 登録されているキーワードはテスト用のデータ
+      expect(result.current.keywords).toEqual(mockKeywords);
+      // 設定するキーワードはキーワードとして登録済み
+      expect(
+        result.current.keywords.some((k) => k.keyword_name === NOLINKED_KEYWORD.keyword_name)
+      ).toBe(true);
+      // 設定するブックマークにはキーワードとして登録されていない
+      expect(
+        bookmarkToSelect.keywords.some((k) => k.keyword_name === NOLINKED_KEYWORD.keyword_name)
+      ).toBe(false);
+      // Act
+      await act(async () => {
+        await result.current.addKeyword(
+          bookmarkToSelect.bookmark_id,
+          NOLINKED_KEYWORD.keyword_name
+        );
+      });
+
+      // Assert
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${BOOKMARKS_ENDPOINT}/${bookmarkToSelect.bookmark_id}/keywords`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              keyword_name: NOLINKED_KEYWORD.keyword_name,
+            }),
+          }
+        );
+      });
+      const afterKeywords = result.current.keywords;
+      expect(afterKeywords).toHaveLength(mockKeywords.length);
+      expect(afterKeywords.some((k) => k.keyword_name === NOLINKED_KEYWORD.keyword_name)).toBe(
+        true
+      );
+      // ブックマークの状態も更新されていることを確認
+      const updatedBookmark = result.current.bookmarks.find(
+        (b) => b.bookmark_id === bookmarkToSelect.bookmark_id
+      );
+      expect(
+        updatedBookmark?.keywords.some((k) => k.keyword_name === NOLINKED_KEYWORD.keyword_name)
+      ).toBe(true);
+    });
   });
 
   describe("エラーの出力をテストする", () => {});

--- a/src/app/hooks/useBookmark.addKeyword.test.ts
+++ b/src/app/hooks/useBookmark.addKeyword.test.ts
@@ -35,7 +35,6 @@ describe("useBookmarks - addKeyword", () => {
 
     it("未登録のキーワードを追加する", async () => {
       // Arrange
-
       const newKeywordId = 99;
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
@@ -163,5 +162,78 @@ describe("useBookmarks - addKeyword", () => {
     });
   });
 
-  describe("エラーの出力をテストする", () => {});
+  describe("エラーの出力をテストする", () => {
+    let consoleErrorSpy: MockInstance;
+
+    beforeEach(() => {
+      // console.errorをスパイして、エラー出力がされるか確認
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    const errorTestCases: { description: string; status: number; errorMessage: string }[] = [
+      {
+        description: "指定されたブックマークが見つからない (404)",
+        status: 404,
+        errorMessage: "指定されたブックマークがありません。",
+      },
+      {
+        description: "キーワードが既に登録済み (409)",
+        status: 409,
+        errorMessage: "指定されたキーワードは既にこのブックマークに登録されています。",
+      },
+      // ... 他のエラーケース
+      {
+        description: "サーバー内部エラー (500)",
+        status: 500,
+        errorMessage: "サーバー内部でエラーが発生しました。",
+      },
+    ];
+    it.each(errorTestCases)("$description", async ({ status, errorMessage }) => {
+      // Arrange
+      const { result } = renderHook(() => useBookmarks());
+      await act(async () => {
+        await result.current.getBookmarks();
+        await result.current.getKeywords();
+      });
+      const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(result.current.bookmarks, 0); // キーワードが0個のブックマークを選択
+
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          message: errorMessage,
+          status: status,
+          isOk: false,
+        })
+      );
+      // Act
+      await expect(
+        result.current.addKeyword(bookmarkToSelect.bookmark_id, NOLINKED_KEYWORD.keyword_name)
+      ).rejects.toThrow();
+
+      // Assert
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${BOOKMARKS_ENDPOINT}/${bookmarkToSelect.bookmark_id}/keywords`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              keyword_name: NOLINKED_KEYWORD.keyword_name,
+            }),
+          }
+        );
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          "キーワードの追加エラー:",
+          expect.stringContaining(errorMessage)
+        );
+      });
+    });
+  });
 });

--- a/src/app/hooks/useBookmark.addKeyword.test.ts
+++ b/src/app/hooks/useBookmark.addKeyword.test.ts
@@ -5,6 +5,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { BOOKMARKS_ENDPOINT } from "../constants/apiEndpoints";
 import {
   HTTP_STATUS_CONFLICT,
+  HTTP_STATUS_CREATED,
   HTTP_STATUS_INTERNAL_SERVER_ERROR,
   HTTP_STATUS_NOT_FOUND,
   HTTP_STATUS_OK,
@@ -12,19 +13,19 @@ import {
 import {
   buildMockBookmarksWithKeywords,
   createMockResponse,
-  findBookmarkWithAtLeastNKeywords,
-  GOOGLE_BOOKMARK,
   mockKeywords,
   NOLINKED_KEYWORD,
 } from "../test-utils/bookmarkTestUtils";
 import { useBookmarks } from "./useBookmark";
 
 const mockFetch = vi.fn();
+let result: { current: ReturnType<typeof useBookmarks> };
+
 global.fetch = mockFetch;
 
 describe("useBookmarks - addKeyword", () => {
   beforeEach(async () => {
-    mockFetch.mockClear();
+    mockFetch.mockReset();
     const mockDataWithKeywords = buildMockBookmarksWithKeywords();
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify(mockDataWithKeywords), { status: HTTP_STATUS_OK })
@@ -32,6 +33,15 @@ describe("useBookmarks - addKeyword", () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify(mockKeywords), { status: HTTP_STATUS_OK })
     );
+
+    const { result: hookResult } = renderHook(() => useBookmarks());
+    result = hookResult;
+
+    await act(async () => {
+      await result.current.getBookmarks();
+      await result.current.getKeywords();
+    });
+    mockFetch.mockClear(); // mockReset() から mockClear() へ変更
   });
 
   afterEach(() => {
@@ -46,19 +56,15 @@ describe("useBookmarks - addKeyword", () => {
       const newKeywordId = 99;
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
-          message: "キーワードをブックマークに追加しました。",
-          keyword_name: UNREGISTERED_KEYWORD,
           keyword_id: newKeywordId,
+          keyword_name: UNREGISTERED_KEYWORD,
+          status: HTTP_STATUS_CREATED,
         })
       );
-      const { result } = renderHook(() => useBookmarks());
-      await act(async () => {
-        await result.current.getBookmarks();
-        await result.current.getKeywords();
-      });
-      const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(result.current.bookmarks, 0); // キーワードが0個のブックマークを選択
+      const bookmarkToSelect = result.current.bookmarks.find((b) => b.keywords.length === 0)!;
 
       // Actの前の状態を確認
+      expect(bookmarkToSelect).toBeDefined();
       // 登録されているキーワードはテスト用のデータ
       expect(result.current.keywords).toEqual(mockKeywords);
       // 設定するキーワードはキーワードとして未登録
@@ -66,7 +72,7 @@ describe("useBookmarks - addKeyword", () => {
         false
       );
       // 設定するブックマークにはキーワードとして登録されていない
-      expect(GOOGLE_BOOKMARK.keywords.some((k) => k.keyword_name === UNREGISTERED_KEYWORD)).toBe(
+      expect(bookmarkToSelect.keywords.some((k) => k.keyword_name === UNREGISTERED_KEYWORD)).toBe(
         false
       );
 
@@ -109,18 +115,13 @@ describe("useBookmarks - addKeyword", () => {
       // Arrange
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
-          message: "キーワードをブックマークに追加しました。",
-          keyword_name: NOLINKED_KEYWORD.keyword_name,
           keyword_id: NOLINKED_KEYWORD.keyword_id,
+          keyword_name: NOLINKED_KEYWORD.keyword_name,
+          status: HTTP_STATUS_CREATED,
         })
       );
-      const { result } = renderHook(() => useBookmarks());
-      await act(async () => {
-        await result.current.getBookmarks();
-        await result.current.getKeywords();
-      });
-      const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(result.current.bookmarks, 0); // キーワードが0個のブックマークを選択
-
+      const bookmarkToSelect = result.current.bookmarks.find((b) => b.keywords.length === 0)!;
+      expect(bookmarkToSelect).toBeDefined();
       // Actの前の状態を確認
       // 登録されているキーワードはテスト用のデータ
       expect(result.current.keywords).toEqual(mockKeywords);
@@ -201,14 +202,8 @@ describe("useBookmarks - addKeyword", () => {
     ];
     it.each(errorTestCases)("$description", async ({ status, errorMessage }) => {
       // Arrange
-      const { result } = renderHook(() => useBookmarks());
-      await act(async () => {
-        await result.current.getBookmarks();
-        await result.current.getKeywords();
-      });
-      const bookmarkToSelect = findBookmarkWithAtLeastNKeywords(result.current.bookmarks, 0); // キーワードが0個のブックマークを選択
+      const bookmarkToSelect = result.current.bookmarks.find((b) => b.keywords.length === 0)!;
 
-      mockFetch.mockReset();
       mockFetch.mockResolvedValueOnce(
         createMockResponse({
           message: errorMessage,

--- a/src/app/hooks/useBookmark.addKeyword.test.ts
+++ b/src/app/hooks/useBookmark.addKeyword.test.ts
@@ -154,6 +154,35 @@ describe("useBookmarks - addKeyword", () => {
       // ブックマークの状態も更新されていることを確認
       assertBookmarkUpdatedWithKeyword(bookmarkToSelect.bookmark_id, NOLINKED_KEYWORD.keyword_name);
     });
+
+    it("既存のキーワードの名前が変更された場合に更新する", async () => {
+      // Arrange
+      const keywordToUpdate = result.current.keywords[0];
+      const updatedKeywordName = "更新されたキーワード名";
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          keyword_id: keywordToUpdate.keyword_id,
+          keyword_name: updatedKeywordName,
+          status: HTTP_STATUS_CREATED,
+        })
+      );
+      const bookmarkToSelect = result.current.bookmarks.find((b) => b.keywords.length === 0)!;
+
+      // Act
+      await act(async () => {
+        await result.current.addKeyword(bookmarkToSelect.bookmark_id, updatedKeywordName);
+      });
+
+      // Assert
+      await assertAddKeywordApiCall(bookmarkToSelect.bookmark_id, updatedKeywordName);
+      const updatedKeyword = result.current.keywords.find(
+        (k) => k.keyword_id === keywordToUpdate.keyword_id
+      );
+      expect(updatedKeyword?.keyword_name).toBe(updatedKeywordName);
+      expect(result.current.keywords).toHaveLength(mockKeywords.length);
+      // ブックマークの状態も更新されていることを確認
+      assertBookmarkUpdatedWithKeyword(bookmarkToSelect.bookmark_id, updatedKeywordName);
+    });
   });
 
   describe("エラーの出力をテストする", () => {

--- a/src/app/hooks/useBookmark.addKeyword.test.ts
+++ b/src/app/hooks/useBookmark.addKeyword.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from "vitest";
+
+import { act, renderHook } from "@testing-library/react";
+
+import {
+  buildMockBookmarksWithKeywords,
+  createMockResponse,
+  GOOGLE_BOOKMARK,
+  mockKeywords,
+} from "../test-utils/bookmarkTestUtils";
+
+import { useBookmarks } from "./useBookmark";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("useBookmarks - addKeyword", () => {
+  beforeEach(async () => {
+    mockFetch.mockClear();
+    const mockDataWithKeywords = buildMockBookmarksWithKeywords();
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(mockDataWithKeywords), { status: 200 })
+    );
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify(mockKeywords), { status: 200 }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("正常系のテスト", () => {
+    const UNREGISTERED_KEYWORD = "未登録のキーワード";
+
+    it("未登録のキーワードを追加する", async () => {
+      // Arrange
+      const newKeywordId = 99;
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse({
+          message: "キーワードをブックマークに追加しました。",
+          keyword_name: UNREGISTERED_KEYWORD,
+          keyword_id: newKeywordId,
+        })
+      );
+      const { result } = renderHook(() => useBookmarks());
+      await act(async () => {
+        await result.current.getBookmarks();
+        await result.current.getKeywords();
+      });
+
+      // Actの前の状態を確認
+      expect(result.current.keywords).toEqual(mockKeywords);
+      expect(result.current.keywords.some((k) => k.keyword_name === UNREGISTERED_KEYWORD)).toBe(
+        false
+      );
+      // Act
+      await act(async () => {
+        await result.current.addKeyword(GOOGLE_BOOKMARK.bookmark_id, UNREGISTERED_KEYWORD);
+      });
+
+      // Assert
+      const afterKeywords = result.current.keywords;
+      expect(afterKeywords).toHaveLength(mockKeywords.length + 1);
+      const addedKeyword = afterKeywords[afterKeywords.length - 1];
+      expect(addedKeyword.keyword_name).toBe("未登録のキーワード");
+      expect(addedKeyword.keyword_id).toBe(newKeywordId);
+    });
+    it("登録済みのキーワードを設定する", () => {});
+  });
+
+  describe("エラーの出力をテストする", () => {});
+});

--- a/src/app/hooks/useBookmark.ts
+++ b/src/app/hooks/useBookmark.ts
@@ -115,10 +115,16 @@ export const useBookmarks = () => {
             : bookmark
         )
       );
-      // 既存のキーワードリストにない場合のみ追加する
       setKeywords((currentKeywords) => {
-        const isAlreadyExist = currentKeywords.some((k) => k.keyword_id === newKeyword.keyword_id);
-        return isAlreadyExist ? currentKeywords : [...currentKeywords, newKeyword];
+        const keywordExists = currentKeywords.some((k) => k.keyword_id === newKeyword.keyword_id);
+        if (keywordExists) {
+          // 既存のキーワードを更新して、名前の変更などを反映する
+          return currentKeywords.map((k) =>
+            k.keyword_id === newKeyword.keyword_id ? newKeyword : k
+          );
+        }
+        // 新しいキーワードを追加する
+        return [...currentKeywords, newKeyword];
       });
       return;
     } catch (error: unknown) {

--- a/src/app/hooks/useBookmark.ts
+++ b/src/app/hooks/useBookmark.ts
@@ -115,6 +115,11 @@ export const useBookmarks = () => {
             : bookmark
         )
       );
+      // 既存のキーワードリストにない場合のみ追加する
+      setKeywords((currentKeywords) => {
+        const isAlreadyExist = currentKeywords.some((k) => k.keyword_id === newKeyword.keyword_id);
+        return isAlreadyExist ? currentKeywords : [...currentKeywords, newKeyword];
+      });
       return;
     } catch (error: unknown) {
       console.error("キーワードの追加エラー:", getErrorMessage(error)); // 詳細なエラーはコンソールへ

--- a/src/app/hooks/useBookmark.ts
+++ b/src/app/hooks/useBookmark.ts
@@ -117,14 +117,20 @@ export const useBookmarks = () => {
       );
       setKeywords((currentKeywords) => {
         const index = currentKeywords.findIndex((k) => k.keyword_id === newKeyword.keyword_id);
-        if (index !== -1) {
-          // 既存のキーワードを更新して、名前の変更などを反映する
-          const updatedKeywords = [...currentKeywords];
-          updatedKeywords[index] = newKeyword;
-          return updatedKeywords;
+        if (index === -1) {
+          // 新しいキーワードなので追加
+          return [...currentKeywords, newKeyword];
         }
-        // 新しいキーワードを追加する
-        return [...currentKeywords, newKeyword];
+
+        // 既存のキーワードと内容が同じ場合は、ステートを更新しない
+        if (currentKeywords[index].keyword_name === newKeyword.keyword_name) {
+          return currentKeywords;
+        }
+
+        // キーワード名が変更されている場合のみ更新
+        const updatedKeywords = [...currentKeywords];
+        updatedKeywords[index] = newKeyword;
+        return updatedKeywords;
       });
       return;
     } catch (error: unknown) {

--- a/src/app/hooks/useBookmark.ts
+++ b/src/app/hooks/useBookmark.ts
@@ -116,12 +116,12 @@ export const useBookmarks = () => {
         )
       );
       setKeywords((currentKeywords) => {
-        const keywordExists = currentKeywords.some((k) => k.keyword_id === newKeyword.keyword_id);
-        if (keywordExists) {
+        const index = currentKeywords.findIndex((k) => k.keyword_id === newKeyword.keyword_id);
+        if (index !== -1) {
           // 既存のキーワードを更新して、名前の変更などを反映する
-          return currentKeywords.map((k) =>
-            k.keyword_id === newKeyword.keyword_id ? newKeyword : k
-          );
+          const updatedKeywords = [...currentKeywords];
+          updatedKeywords[index] = newKeyword;
+          return updatedKeywords;
         }
         // 新しいキーワードを追加する
         return [...currentKeywords, newKeyword];


### PR DESCRIPTION
## 概要

`useBookmark` フックの `addKeyword` 関数を改善し、キーワードがグローバルなキーワード一覧に重複して登録される問題を修正しました。
あわせて、この関数の正常系・異常系を網羅する包括的なテストを実装し、機能の堅牢性を向上させました。

## 変更内容

### 🚀 機能改善

-   **キーワードの重複登録防止**:
    -   `addKeyword` 関数に、追加対象のキーワードが既に `keywords` state に存在するかをチェックするロジックを追加しました。
    -   これにより、APIから新しいキーワード情報が返された場合でも、既存のキーワード一覧に重複して追加されることがなくなりました。

### ✅ テストの追加・拡充

-   `useBookmark.addKeyword.test.ts` を新設し、`addKeyword` 関数の動作を検証するテストケースを実装しました。

-   **正常系テスト**:
    -   未登録のキーワードをブックマークに追加するケース
    -   既存のキーワードをブックマークに追加するケース
    -   上記のケースで、`bookmarks` と `keywords` の state が期待通りに更新されることを確認します。

-   **異常系テスト**:
    -   APIがエラーを返した場合の動作を網羅的にテストします。
        -   `404 Not Found` (指定されたブックマークが見つからない)
        -   `409 Conflict` (キーワードが既に登録済み)
        -   `500 Internal Server Error` (サーバー内部エラー)

### 🧹 リファクタリング

-   テストコード内で使用していたHTTPステータスコードのマジックナンバーを、`httpStatusCodes.ts` からインポートした定数に置き換え、コードの可読性と保守性を向上させました。