### PR TITLE
test(hooks): useBookmarkManagerのテストを強化・リファクタリング

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "dependencies": {
         "better-sqlite3": "^12.2.0",
         "next": "15.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/src/app/hooks/useBookmarkManager.test.tsx
+++ b/src/app/hooks/useBookmarkManager.test.tsx
@@ -230,7 +230,7 @@ describe("useBookmarkManager", () => {
 
         // Assert
         await waitFor(() => {
-          // deleteBookmarkの呼び出し
+          // updateBookmarkの呼び出し
           expect(updateBookmark).toHaveBeenCalledWith(
             LINKPAGE_BOOKMARK.bookmark_id,
             LINKPAGE_BOOKMARK.url,

--- a/src/app/hooks/useBookmarkManager.test.tsx
+++ b/src/app/hooks/useBookmarkManager.test.tsx
@@ -184,7 +184,7 @@ describe("useBookmarkManager", () => {
       });
     });
 
-    it("ブックマークを選択してキーワードを解除するとunlinkKeywordが呼び出される", async () => {
+    it("ブックマークを選択してキーワードの解除ボタンをクリックするとunlinkKeywordが呼び出される", async () => {
       const { result } = renderMyHook();
 
       // 1. ブックマークを選択する
@@ -216,7 +216,7 @@ describe("useBookmarkManager", () => {
       });
     });
 
-    it("ブックマークを選択してキーワードを解除するとlinkKeywordが呼び出される", async () => {
+    it("ブックマークを選択してキーワードの設定ボタンをクリックするとlinkKeywordが呼び出される", async () => {
       const { result } = renderMyHook();
 
       // 1. ブックマークを選択する

--- a/src/app/hooks/useBookmarkManager.test.tsx
+++ b/src/app/hooks/useBookmarkManager.test.tsx
@@ -66,11 +66,11 @@ describe("useBookmarkManager", () => {
       });
 
       // Act
-      act(() => {
-        result.current.deleteClick();
-        result.current.updateClick();
-        result.current.addKeywordClick();
-        result.current.unlinkKeywordClick(LINKED_KEYWORD);
+      await act(async () => {
+        await result.current.deleteClick();
+        await result.current.updateClick();
+        await result.current.addKeywordClick();
+        await result.current.unlinkKeywordClick(LINKED_KEYWORD);
       });
 
       // Assert
@@ -102,8 +102,8 @@ describe("useBookmarkManager", () => {
     it("キーワードを指定しないで設定ボタンをクリックするとlinkKeywordが呼び出されない", async () => {
       // Arrange: 空のキーワードで設定ボタンのクリックをシミュレートする
       const emptyKeyword: Keyword = { keyword_id: 0, keyword_name: "" };
-      act(() => {
-        result.current.linkKeywordClick(emptyKeyword);
+      await act(async () => {
+        await result.current.linkKeywordClick(emptyKeyword);
       });
 
       // Assert: addKeywordが呼び出されないことを確認
@@ -115,8 +115,8 @@ describe("useBookmarkManager", () => {
     describe("正常系のテスト", () => {
       it("削除ボタンをクリックするとdeleteBookmarkが呼び出される", async () => {
         // Act
-        act(() => {
-          result.current.deleteClick();
+        await act(async () => {
+          await result.current.deleteClick();
         });
 
         // Assert
@@ -129,8 +129,8 @@ describe("useBookmarkManager", () => {
 
       it("「更新」ボタンをクリックするとupdateBookmarkが呼び出される", async () => {
         // Act
-        act(() => {
-          result.current.updateClick();
+        await act(async () => {
+          await result.current.updateClick();
         });
 
         // Assert
@@ -156,8 +156,8 @@ describe("useBookmarkManager", () => {
         expect(result.current.textKeyword).toBe(newKeyword);
 
         // Act
-        act(() => {
-          result.current.addKeywordClick();
+        await act(async () => {
+          await result.current.addKeywordClick();
         });
 
         // Assert
@@ -170,8 +170,8 @@ describe("useBookmarkManager", () => {
 
       it("キーワードの解除ボタンをクリックするとunlinkKeywordが呼び出される", async () => {
         // Act
-        act(() => {
-          result.current.unlinkKeywordClick(LINKED_KEYWORD);
+        await act(async () => {
+          await result.current.unlinkKeywordClick(LINKED_KEYWORD);
         });
 
         // Assert
@@ -187,8 +187,8 @@ describe("useBookmarkManager", () => {
 
       it("キーワードの設定ボタンをクリックするとaddKeyword(linkKeyword)が呼び出される", async () => {
         // Act
-        act(() => {
-          result.current.linkKeywordClick(LINKED_KEYWORD);
+        await act(async () => {
+          await result.current.linkKeywordClick(LINKED_KEYWORD);
         });
 
         // Assert

--- a/src/app/hooks/useBookmarkManager.test.tsx
+++ b/src/app/hooks/useBookmarkManager.test.tsx
@@ -81,366 +81,245 @@ describe("useBookmarkManager", () => {
         expect(unlinkKeyword).toHaveBeenCalledTimes(0);
       });
     });
+  });
 
-    describe("ブックマーク選択後の不正な入力", () => {
-      let result: ReturnType<typeof renderMyHook>["result"];
+  describe("ブックマーク選択後のテスト", () => {
+    let result: ReturnType<typeof renderMyHook>["result"];
 
-      beforeEach(async () => {
-        const hook = renderMyHook();
-        result = hook.result;
+    beforeEach(async () => {
+      const hook = renderMyHook();
+      result = hook.result;
 
+      act(() => {
+        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+      });
+
+      await waitFor(() => {
+        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+      });
+    });
+
+    it("キーワードを指定しないで設定ボタンをクリックするとlinkKeywordが呼び出されない", async () => {
+      // Arrange: 空のキーワードで設定ボタンのクリックをシミュレートする
+      const emptyKeyword: Keyword = { keyword_id: 0, keyword_name: "" };
+      act(() => {
+        result.current.linkKeywordClick(emptyKeyword);
+      });
+
+      // Assert: addKeywordが呼び出されないことを確認
+      await waitFor(() => {
+        expect(addKeyword).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe("正常系のテスト", () => {
+      it("削除ボタンをクリックするとdeleteBookmarkが呼び出される", async () => {
+        // Act
         act(() => {
-          result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+          result.current.deleteClick();
         });
 
+        // Assert
         await waitFor(() => {
+          expect(deleteBookmark).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id);
+          expect(result.current.textMessage).toBe("");
+          expect(result.current.selectedBookmarkId).toBe(undefined);
+        });
+      });
+
+      it("「更新」ボタンをクリックするとupdateBookmarkが呼び出される", async () => {
+        // Act
+        act(() => {
+          result.current.updateClick();
+        });
+
+        // Assert
+        await waitFor(() => {
+          expect(updateBookmark).toHaveBeenCalledWith(
+            LINKPAGE_BOOKMARK.bookmark_id,
+            LINKPAGE_BOOKMARK.url,
+            LINKPAGE_BOOKMARK.title
+          );
           expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+          expect(result.current.textTitle).toBe(LINKPAGE_BOOKMARK.title);
+          expect(result.current.textMessage).toBe("");
+          expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
         });
       });
 
-      it("キーワードを指定しないで設定ボタンをクリックするとlinkKeywordが呼び出されない", async () => {
-        // Arrange: 空のキーワードで設定ボタンのクリックをシミュレートする
-        const emptyKeyword: Keyword = { keyword_id: 0, keyword_name: "" };
+      it("キーワードを入力して「追加」ボタンをクリックするとaddKeywordが呼び出される", async () => {
+        // Arrange
+        const newKeyword = "new keyword";
         act(() => {
-          result.current.linkKeywordClick(emptyKeyword);
+          result.current.setTextKeyword(newKeyword);
         });
-
-        // Assert: addKeywordが呼び出されないことを確認
-        await waitFor(() => {
-          expect(addKeyword).toHaveBeenCalledTimes(0);
-        });
-      });
-    });
-  });
-
-  describe("正常系のテスト", () => {
-    it("ブックマークを選択して削除ボタンをクリックするとdeleteBookmarkが呼び出される", async () => {
-      // Arrange
-      // 1. ブックマークを選択する
-      const { result } = renderMyHook();
-      act(() => {
-        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-
-      // 2. ブックマーク選択による副作用(useEffect)が完了し、フォームが更新されるのを待つ
-      await waitFor(() => {
-        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
-      });
-
-      // Act
-      // 3. ボタンをクリックする
-      act(() => {
-        result.current.deleteClick();
-      });
-
-      // 4. 結果を検証する
-      await waitFor(() => {
-        expect(deleteBookmark).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id);
-
-        // エラーメッセージと選択されたブックマーク
-        expect(result.current.textMessage).toBe("");
-        expect(result.current.selectedBookmarkId).toBe(undefined);
-      });
-    });
-
-    it("ブックマークを選択して「更新」ボタンをクリックするとupdateBookmarkが呼び出される", async () => {
-      const { result } = renderMyHook();
-
-      // 1. ブックマークを選択する
-      act(() => {
-        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-
-      // 2. ブックマーク選択による副作用(useEffect)が完了し、フォームが更新されるのを待つ
-      await waitFor(() => {
-        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
-      });
-
-      // 3. 更新ボタンをクリックする
-      act(() => {
-        result.current.updateClick();
-      });
-
-      // 4. 結果を検証する
-      await waitFor(() => {
-        // updateBookmarkの呼び出し
-        expect(updateBookmark).toHaveBeenCalledWith(
-          LINKPAGE_BOOKMARK.bookmark_id,
-          LINKPAGE_BOOKMARK.url,
-          LINKPAGE_BOOKMARK.title
-        );
-
-        // フォームの値が期待通りに設定されていることを確認
-        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
-        expect(result.current.textTitle).toBe(LINKPAGE_BOOKMARK.title);
-
-        // エラーメッセージとキーワードの選択されたブックマーク
-        expect(result.current.textMessage).toBe("");
-        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-    });
-
-    it("ブックマークを選択してキーワードを入力して「追加」ボタンをクリックするとaddKeywordが呼び出される", async () => {
-      const { result } = renderMyHook();
-
-      const newKeyword = "new keyword";
-
-      // Arrange: ブックマークを選択し、キーワードを入力する
-      act(() => {
-        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-
-      await waitFor(() => {
-        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
-      });
-
-      act(() => {
-        result.current.setTextKeyword(newKeyword);
-      });
-      expect(result.current.textKeyword).toBe(newKeyword);
-
-      // Act: 追加ボタンをクリックする
-      act(() => {
-        result.current.addKeywordClick();
-      });
-
-      // Assert: addKeywordが呼び出され、フォームがリセットされることを確認する
-      await waitFor(() => {
-        // addKeywordの呼び出し
-        expect(addKeyword).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id, newKeyword);
-
-        // エラーメッセージとキーワードのテキストボックス
-        expect(result.current.textMessage).toBe("");
-        expect(result.current.textKeyword).toBe("");
-      });
-    });
-
-    it("ブックマークを選択してキーワードの解除ボタンをクリックするとunlinkKeywordが呼び出される", async () => {
-      const { result } = renderMyHook();
-
-      // 1. ブックマークを選択する
-      act(() => {
-        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-
-      // 2. ブックマーク選択による副作用(useEffect)が完了し、フォームが更新されるのを待つ
-      await waitFor(() => {
-        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
-      });
-
-      // 3. キーワード解除をクリックする
-      act(() => {
-        result.current.unlinkKeywordClick(LINKED_KEYWORD);
-      });
-
-      // 4. 結果を検証する
-      await waitFor(() => {
-        // unlinkKeywordの呼び出し
-        expect(unlinkKeyword).toHaveBeenCalledWith(
-          LINKPAGE_BOOKMARK.bookmark_id, // 選択されたブックマークのID
-          LINKED_KEYWORD.keyword_id // 解除されるキーワードのID
-        );
-
-        // エラーメッセージと選択されたブックマーク
-        expect(result.current.textMessage).toBe("");
-        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-    });
-
-    it("ブックマークを選択してキーワードの設定ボタンをクリックするとlinkKeywordが呼び出される", async () => {
-      const { result } = renderMyHook();
-
-      // 1. ブックマークを選択する
-      act(() => {
-        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-
-      // 2. ブックマーク選択による副作用(useEffect)が完了し、フォームが更新されるのを待つ
-      await waitFor(() => {
-        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
-      });
-
-      // 3. キーワード解除をクリックする
-      act(() => {
-        result.current.linkKeywordClick(LINKED_KEYWORD);
-      });
-
-      // 4. 結果を検証する
-      await waitFor(() => {
-        // unlinkKeywordの呼び出し
-        expect(addKeyword).toHaveBeenCalledWith(
-          LINKPAGE_BOOKMARK.bookmark_id, // 選択されたブックマークのID
-          LINKED_KEYWORD.keyword_name // 解除されるキーワードの文字列
-        );
-
-        // エラーメッセージと選択されたブックマーク
-        expect(result.current.textMessage).toBe("");
-        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-    });
-  });
-
-  describe("エラー系のテスト", () => {
-    it("deleteClick: deleteBookmarkに失敗するとエラーメッセージが表示される", async () => {
-      // Arrange
-      vi.mocked(deleteBookmark).mockRejectedValueOnce(new Error("エラーが発生しました"));
-
-      const { result } = renderMyHook();
-
-      act(() => {
-        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-      await waitFor(() => {
-        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
-      });
-
-      // Act
-      await act(async () => {
-        await result.current.deleteClick();
-      });
-
-      // Assert
-      await waitFor(() => {
-        // deleteBookmarkの呼び出し
-        expect(deleteBookmark).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id);
-
-        // エラーメッセージと選択されたブックマーク
-        expect(result.current.textMessage).toBe("エラーが発生しました");
-        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-    });
-
-    it("updateClick: updateBookmarkに失敗するとエラーメッセージが表示される", async () => {
-      // Arrange
-      vi.mocked(updateBookmark).mockRejectedValueOnce(new Error("エラーが発生しました"));
-
-      const { result } = renderMyHook();
-
-      act(() => {
-        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-      await waitFor(() => {
-        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
-      });
-
-      // Act
-      await act(async () => {
-        await result.current.updateClick();
-      });
-
-      // Assert
-      await waitFor(() => {
-        // deleteBookmarkの呼び出し
-        expect(updateBookmark).toHaveBeenCalledWith(
-          LINKPAGE_BOOKMARK.bookmark_id,
-          LINKPAGE_BOOKMARK.url,
-          LINKPAGE_BOOKMARK.title
-        );
-
-        // エラーメッセージと選択されたブックマーク
-        expect(result.current.textMessage).toBe("エラーが発生しました");
-        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-    });
-
-    it("addKeywordClick: addKeywordに失敗するとエラーメッセージが表示される", async () => {
-      // Arrange
-      vi.mocked(addKeyword).mockRejectedValueOnce(new Error("エラーが発生しました"));
-
-      const { result } = renderMyHook();
-      const newKeyword = "new keyword";
-
-      act(() => {
-        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-      await waitFor(() => {
-        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
-      });
-
-      act(() => {
-        result.current.setTextKeyword(newKeyword);
-      });
-      await waitFor(() => {
         expect(result.current.textKeyword).toBe(newKeyword);
+
+        // Act
+        act(() => {
+          result.current.addKeywordClick();
+        });
+
+        // Assert
+        await waitFor(() => {
+          expect(addKeyword).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id, newKeyword);
+          expect(result.current.textMessage).toBe("");
+          expect(result.current.textKeyword).toBe("");
+        });
       });
 
-      // Act
-      await act(async () => {
-        await result.current.addKeywordClick();
+      it("キーワードの解除ボタンをクリックするとunlinkKeywordが呼び出される", async () => {
+        // Act
+        act(() => {
+          result.current.unlinkKeywordClick(LINKED_KEYWORD);
+        });
+
+        // Assert
+        await waitFor(() => {
+          expect(unlinkKeyword).toHaveBeenCalledWith(
+            LINKPAGE_BOOKMARK.bookmark_id,
+            LINKED_KEYWORD.keyword_id
+          );
+          expect(result.current.textMessage).toBe("");
+          expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+        });
       });
 
-      // Assert
-      await waitFor(() => {
-        // addKeywordの呼び出し
-        expect(addKeyword).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id, newKeyword);
+      it("キーワードの設定ボタンをクリックするとaddKeyword(linkKeyword)が呼び出される", async () => {
+        // Act
+        act(() => {
+          result.current.linkKeywordClick(LINKED_KEYWORD);
+        });
 
-        // エラーメッセージと選択されたブックマーク
-        expect(result.current.textMessage).toBe("エラーが発生しました");
-        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+        // Assert
+        await waitFor(() => {
+          expect(addKeyword).toHaveBeenCalledWith(
+            LINKPAGE_BOOKMARK.bookmark_id,
+            LINKED_KEYWORD.keyword_name
+          );
+          expect(result.current.textMessage).toBe("");
+          expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+        });
       });
     });
 
-    it("unlinkKeywordClick: unlinkKeywordに失敗するとエラーメッセージが表示される", async () => {
-      // Arrange
-      vi.mocked(unlinkKeyword).mockRejectedValueOnce(new Error("エラーが発生しました"));
+    describe("エラー系のテスト", () => {
+      it("deleteClick: deleteBookmarkに失敗するとエラーメッセージが表示される", async () => {
+        // Arrange
+        vi.mocked(deleteBookmark).mockRejectedValueOnce(new Error("エラーが発生しました"));
 
-      const { result } = renderMyHook();
+        // Act
+        await act(async () => {
+          await result.current.deleteClick();
+        });
 
-      act(() => {
-        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-      await waitFor(() => {
-        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
-      });
+        // Assert
+        await waitFor(() => {
+          // deleteBookmarkの呼び出し
+          expect(deleteBookmark).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id);
 
-      // Act
-      await act(async () => {
-        await result.current.unlinkKeywordClick(LINKED_KEYWORD);
-      });
-
-      // Assert
-      await waitFor(() => {
-        // unlinkKeywordの呼び出し
-        expect(unlinkKeyword).toHaveBeenCalledWith(
-          LINKPAGE_BOOKMARK.bookmark_id,
-          LINKED_KEYWORD.keyword_id
-        );
-
-        // エラーメッセージと選択されたブックマーク
-        expect(result.current.textMessage).toBe("エラーが発生しました");
-        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-    });
-
-    it("linkKeywordClick: addKeywordに失敗するとエラーメッセージが表示される", async () => {
-      // Arrange
-      vi.mocked(addKeyword).mockRejectedValueOnce(new Error("エラーが発生しました"));
-
-      const { result } = renderMyHook();
-
-      act(() => {
-        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
-      });
-      await waitFor(() => {
-        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+          // エラーメッセージと選択されたブックマーク
+          expect(result.current.textMessage).toBe("エラーが発生しました");
+          expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+        });
       });
 
-      // Act
-      await act(async () => {
-        await result.current.linkKeywordClick(LINKED_KEYWORD);
+      it("updateClick: updateBookmarkに失敗するとエラーメッセージが表示される", async () => {
+        // Arrange
+        vi.mocked(updateBookmark).mockRejectedValueOnce(new Error("エラーが発生しました"));
+
+        // Act
+        await act(async () => {
+          await result.current.updateClick();
+        });
+
+        // Assert
+        await waitFor(() => {
+          // deleteBookmarkの呼び出し
+          expect(updateBookmark).toHaveBeenCalledWith(
+            LINKPAGE_BOOKMARK.bookmark_id,
+            LINKPAGE_BOOKMARK.url,
+            LINKPAGE_BOOKMARK.title
+          );
+
+          // エラーメッセージと選択されたブックマーク
+          expect(result.current.textMessage).toBe("エラーが発生しました");
+          expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+        });
       });
 
-      // Assert
-      await waitFor(() => {
-        // addKeywordの呼び出し
-        expect(addKeyword).toHaveBeenCalledWith(
-          LINKPAGE_BOOKMARK.bookmark_id,
-          LINKED_KEYWORD.keyword_name
-        );
+      it("addKeywordClick: addKeywordに失敗するとエラーメッセージが表示される", async () => {
+        // Arrange
+        vi.mocked(addKeyword).mockRejectedValueOnce(new Error("エラーが発生しました"));
 
-        // エラーメッセージと選択されたブックマーク
-        expect(result.current.textMessage).toBe("エラーが発生しました");
-        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+        const newKeyword = "new keyword";
+        act(() => {
+          result.current.setTextKeyword(newKeyword);
+        });
+        await waitFor(() => {
+          expect(result.current.textKeyword).toBe(newKeyword);
+        });
+
+        // Act
+        await act(async () => {
+          await result.current.addKeywordClick();
+        });
+
+        // Assert
+        await waitFor(() => {
+          // addKeywordの呼び出し
+          expect(addKeyword).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id, newKeyword);
+
+          // エラーメッセージと選択されたブックマーク
+          expect(result.current.textMessage).toBe("エラーが発生しました");
+          expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+        });
+      });
+
+      it("unlinkKeywordClick: unlinkKeywordに失敗するとエラーメッセージが表示される", async () => {
+        // Arrange
+        vi.mocked(unlinkKeyword).mockRejectedValueOnce(new Error("エラーが発生しました"));
+
+        // Act
+        await act(async () => {
+          await result.current.unlinkKeywordClick(LINKED_KEYWORD);
+        });
+
+        // Assert
+        await waitFor(() => {
+          // unlinkKeywordの呼び出し
+          expect(unlinkKeyword).toHaveBeenCalledWith(
+            LINKPAGE_BOOKMARK.bookmark_id,
+            LINKED_KEYWORD.keyword_id
+          );
+
+          // エラーメッセージと選択されたブックマーク
+          expect(result.current.textMessage).toBe("エラーが発生しました");
+          expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+        });
+      });
+
+      it("linkKeywordClick: addKeywordに失敗するとエラーメッセージが表示される", async () => {
+        // Arrange
+        vi.mocked(addKeyword).mockRejectedValueOnce(new Error("エラーが発生しました"));
+
+        // Act
+        await act(async () => {
+          await result.current.linkKeywordClick(LINKED_KEYWORD);
+        });
+
+        // Assert
+        await waitFor(() => {
+          // addKeywordの呼び出し
+          expect(addKeyword).toHaveBeenCalledWith(
+            LINKPAGE_BOOKMARK.bookmark_id,
+            LINKED_KEYWORD.keyword_name
+          );
+
+          // エラーメッセージと選択されたブックマーク
+          expect(result.current.textMessage).toBe("エラーが発生しました");
+          expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+        });
       });
     });
   });

--- a/src/app/hooks/useBookmarkManager.test.tsx
+++ b/src/app/hooks/useBookmarkManager.test.tsx
@@ -64,10 +64,12 @@ describe("useBookmarkManager", () => {
 
       // Act
       await act(async () => {
-        await result.current.deleteClick();
-        await result.current.updateClick();
-        await result.current.addKeywordClick();
-        await result.current.unlinkKeywordClick(LINKED_KEYWORD);
+        await Promise.all([
+          result.current.deleteClick(),
+          result.current.updateClick(),
+          result.current.addKeywordClick(),
+          result.current.unlinkKeywordClick(LINKED_KEYWORD),
+        ]);
       });
 
       // Assert

--- a/src/app/hooks/useBookmarkManager.test.tsx
+++ b/src/app/hooks/useBookmarkManager.test.tsx
@@ -5,6 +5,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { LINKED_KEYWORD, LINKPAGE_BOOKMARK, mockBookmarks } from "../test-utils/bookmarkTestUtils";
 import { Bookmark } from "../types/Bookmark";
 import { useBookmarkManager } from "./useBookmarkManager";
+import { Keyword } from "../types/Keyword";
 
 describe("useBookmarkManager", () => {
   let bookmarks: Bookmark[];
@@ -56,7 +57,7 @@ describe("useBookmarkManager", () => {
     });
   });
 
-  describe("ブックマークを選択しない場合", () => {
+  describe("不正な入力の場合", () => {
     it("ブックマークを選択しないでボタンをクリックしても関数は呼び出されない", async () => {
       // Arrange
       const { result } = renderMyHook();
@@ -78,6 +79,36 @@ describe("useBookmarkManager", () => {
         expect(updateBookmark).toHaveBeenCalledTimes(0);
         expect(addKeyword).toHaveBeenCalledTimes(0);
         expect(unlinkKeyword).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe("ブックマーク選択後の不正な入力", () => {
+      let result: ReturnType<typeof renderMyHook>["result"];
+
+      beforeEach(async () => {
+        const hook = renderMyHook();
+        result = hook.result;
+
+        act(() => {
+          result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+        });
+
+        await waitFor(() => {
+          expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+        });
+      });
+
+      it("キーワードを指定しないで設定ボタンをクリックするとlinkKeywordが呼び出されない", async () => {
+        // Arrange: 空のキーワードで設定ボタンのクリックをシミュレートする
+        const emptyKeyword: Keyword = { keyword_id: 0, keyword_name: "" };
+        act(() => {
+          result.current.linkKeywordClick(emptyKeyword);
+        });
+
+        // Assert: addKeywordが呼び出されないことを確認
+        await waitFor(() => {
+          expect(addKeyword).toHaveBeenCalledTimes(0);
+        });
       });
     });
   });

--- a/src/app/hooks/useBookmarkManager.test.tsx
+++ b/src/app/hooks/useBookmarkManager.test.tsx
@@ -212,7 +212,6 @@ describe("useBookmarkManager", () => {
 
         // Assert
         await waitFor(() => {
-          // deleteBookmarkの呼び出し
           expect(deleteBookmark).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id);
 
           // エラーメッセージと選択されたブックマーク
@@ -232,7 +231,6 @@ describe("useBookmarkManager", () => {
 
         // Assert
         await waitFor(() => {
-          // updateBookmarkの呼び出し
           expect(updateBookmark).toHaveBeenCalledWith(
             LINKPAGE_BOOKMARK.bookmark_id,
             LINKPAGE_BOOKMARK.url,
@@ -264,7 +262,6 @@ describe("useBookmarkManager", () => {
 
         // Assert
         await waitFor(() => {
-          // addKeywordの呼び出し
           expect(addKeyword).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id, newKeyword);
 
           // エラーメッセージと選択されたブックマーク
@@ -284,7 +281,6 @@ describe("useBookmarkManager", () => {
 
         // Assert
         await waitFor(() => {
-          // unlinkKeywordの呼び出し
           expect(unlinkKeyword).toHaveBeenCalledWith(
             LINKPAGE_BOOKMARK.bookmark_id,
             LINKED_KEYWORD.keyword_id
@@ -307,7 +303,6 @@ describe("useBookmarkManager", () => {
 
         // Assert
         await waitFor(() => {
-          // addKeywordの呼び出し
           expect(addKeyword).toHaveBeenCalledWith(
             LINKPAGE_BOOKMARK.bookmark_id,
             LINKED_KEYWORD.keyword_name

--- a/src/app/hooks/useBookmarkManager.test.tsx
+++ b/src/app/hooks/useBookmarkManager.test.tsx
@@ -105,7 +105,7 @@ describe("useBookmarkManager", () => {
 
       // Assert: addKeywordが呼び出されないことを確認
       await waitFor(() => {
-        expect(addKeyword).toHaveBeenCalledTimes(0);
+        expect(addKeyword).not.toHaveBeenCalled();
       });
     });
 

--- a/src/app/hooks/useBookmarkManager.test.tsx
+++ b/src/app/hooks/useBookmarkManager.test.tsx
@@ -61,9 +61,6 @@ describe("useBookmarkManager", () => {
     it("ブックマークを選択しないでボタンをクリックしても関数は呼び出されない", async () => {
       // Arrange
       const { result } = renderMyHook();
-      act(() => {
-        result.current.setSelectedBookmarkId(undefined);
-      });
 
       // Act
       await act(async () => {
@@ -74,12 +71,10 @@ describe("useBookmarkManager", () => {
       });
 
       // Assert
-      await waitFor(() => {
-        expect(deleteBookmark).toHaveBeenCalledTimes(0);
-        expect(updateBookmark).toHaveBeenCalledTimes(0);
-        expect(addKeyword).toHaveBeenCalledTimes(0);
-        expect(unlinkKeyword).toHaveBeenCalledTimes(0);
-      });
+      expect(deleteBookmark).not.toHaveBeenCalled();
+      expect(updateBookmark).not.toHaveBeenCalled();
+      expect(addKeyword).not.toHaveBeenCalled();
+      expect(unlinkKeyword).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/hooks/useBookmarkManager.test.tsx
+++ b/src/app/hooks/useBookmarkManager.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { act, renderHook, waitFor } from "@testing-library/react";
 
-import { LINKPAGE_BOOKMARK, mockBookmarks, LINKED_KEYWORD } from "../test-utils/bookmarkTestUtils";
+import { LINKED_KEYWORD, LINKPAGE_BOOKMARK, mockBookmarks } from "../test-utils/bookmarkTestUtils";
 import { Bookmark } from "../types/Bookmark";
 import { useBookmarkManager } from "./useBookmarkManager";
 
@@ -40,202 +40,377 @@ describe("useBookmarkManager", () => {
     );
   };
 
-  it("useBookmarkManagerを初期化するとgetBookmarksが呼び出される", async () => {
-    const { result } = renderMyHook();
+  describe("getBookmarks", () => {
+    it("useBookmarkManagerを初期化するとgetBookmarksが呼び出される", async () => {
+      const { result } = renderMyHook();
 
-    // 結果を検証する
-    await waitFor(() => {
-      // getBookmarksの呼び出し
-      expect(getBookmarks).toHaveBeenCalledWith();
+      // 結果を検証する
+      await waitFor(() => {
+        // getBookmarksの呼び出し
+        expect(getBookmarks).toHaveBeenCalledWith();
 
-      // エラーメッセージとキーワードのテキストボックス
-      expect(result.current.textMessage).toBe("");
-      expect(result.current.selectedBookmarkId).toBe(undefined);
+        // エラーメッセージとキーワードのテキストボックス
+        expect(result.current.textMessage).toBe("");
+        expect(result.current.selectedBookmarkId).toBe(undefined);
+      });
     });
   });
 
-  it("ブックマークを選択しないで「削除」ボタンを押すとdeleteBookmarkは呼び出されない", async () => {
-    const { result } = renderMyHook();
+  describe("ブックマークを選択しない場合", () => {
+    it("ブックマークを選択しないでボタンをクリックしても関数は呼び出されない", async () => {
+      // Arrange
+      const { result } = renderMyHook();
+      act(() => {
+        result.current.setSelectedBookmarkId(undefined);
+      });
 
-    act(() => {
-      result.current.setSelectedBookmarkId(undefined);
-      result.current.deleteClick();
-    });
+      // Act
+      act(() => {
+        result.current.deleteClick();
+        result.current.updateClick();
+        result.current.addKeywordClick();
+        result.current.unlinkKeywordClick(LINKED_KEYWORD);
+      });
 
-    await waitFor(() => {
-      expect(deleteBookmark).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  it("ブックマークを選択しないで「更新」ボタンを押すとupdateBookmarkは呼び出されない", async () => {
-    const { result } = renderMyHook();
-
-    act(() => {
-      result.current.setSelectedBookmarkId(undefined);
-      result.current.updateClick();
-    });
-
-    await waitFor(() => {
-      expect(updateBookmark).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  it("ブックマークを選択しないで「追加」ボタンを押すとaddKeywordは呼び出されない", async () => {
-    const { result } = renderMyHook();
-
-    act(() => {
-      result.current.setSelectedBookmarkId(undefined);
-      result.current.addKeywordClick();
-    });
-
-    await waitFor(() => {
-      expect(addKeyword).toHaveBeenCalledTimes(0);
+      // Assert
+      await waitFor(() => {
+        expect(deleteBookmark).toHaveBeenCalledTimes(0);
+        expect(updateBookmark).toHaveBeenCalledTimes(0);
+        expect(addKeyword).toHaveBeenCalledTimes(0);
+        expect(unlinkKeyword).toHaveBeenCalledTimes(0);
+      });
     });
   });
 
-  it("ブックマークを選択してキーワードを入力して「追加」ボタンをクリックするとaddKeywordが呼び出される", async () => {
-    const { result } = renderMyHook();
+  describe("正常系のテスト", () => {
+    it("ブックマークを選択して削除ボタンをクリックするとdeleteBookmarkが呼び出される", async () => {
+      // Arrange
+      // 1. ブックマークを選択する
+      const { result } = renderMyHook();
+      act(() => {
+        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+      });
 
-    const newKeyword = "new keyword";
+      // 2. ブックマーク選択による副作用(useEffect)が完了し、フォームが更新されるのを待つ
+      await waitFor(() => {
+        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+      });
 
-    // Arrange: ブックマークを選択し、キーワードを入力する
-    act(() => {
-      result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+      // Act
+      // 3. ボタンをクリックする
+      act(() => {
+        result.current.deleteClick();
+      });
+
+      // 4. 結果を検証する
+      await waitFor(() => {
+        expect(deleteBookmark).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id);
+
+        // エラーメッセージと選択されたブックマーク
+        expect(result.current.textMessage).toBe("");
+        expect(result.current.selectedBookmarkId).toBe(undefined);
+      });
     });
 
-    await waitFor(() => {
-      expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+    it("ブックマークを選択して「更新」ボタンをクリックするとupdateBookmarkが呼び出される", async () => {
+      const { result } = renderMyHook();
+
+      // 1. ブックマークを選択する
+      act(() => {
+        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+      });
+
+      // 2. ブックマーク選択による副作用(useEffect)が完了し、フォームが更新されるのを待つ
+      await waitFor(() => {
+        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+      });
+
+      // 3. 更新ボタンをクリックする
+      act(() => {
+        result.current.updateClick();
+      });
+
+      // 4. 結果を検証する
+      await waitFor(() => {
+        // updateBookmarkの呼び出し
+        expect(updateBookmark).toHaveBeenCalledWith(
+          LINKPAGE_BOOKMARK.bookmark_id,
+          LINKPAGE_BOOKMARK.url,
+          LINKPAGE_BOOKMARK.title
+        );
+
+        // フォームの値が期待通りに設定されていることを確認
+        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+        expect(result.current.textTitle).toBe(LINKPAGE_BOOKMARK.title);
+
+        // エラーメッセージとキーワードの選択されたブックマーク
+        expect(result.current.textMessage).toBe("");
+        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+      });
     });
 
-    act(() => {
-      result.current.setTextKeyword(newKeyword);
+    it("ブックマークを選択してキーワードを入力して「追加」ボタンをクリックするとaddKeywordが呼び出される", async () => {
+      const { result } = renderMyHook();
+
+      const newKeyword = "new keyword";
+
+      // Arrange: ブックマークを選択し、キーワードを入力する
+      act(() => {
+        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+      });
+
+      await waitFor(() => {
+        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+      });
+
+      act(() => {
+        result.current.setTextKeyword(newKeyword);
+      });
+      expect(result.current.textKeyword).toBe(newKeyword);
+
+      // Act: 追加ボタンをクリックする
+      act(() => {
+        result.current.addKeywordClick();
+      });
+
+      // Assert: addKeywordが呼び出され、フォームがリセットされることを確認する
+      await waitFor(() => {
+        // addKeywordの呼び出し
+        expect(addKeyword).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id, newKeyword);
+
+        // エラーメッセージとキーワードのテキストボックス
+        expect(result.current.textMessage).toBe("");
+        expect(result.current.textKeyword).toBe("");
+      });
     });
-    expect(result.current.textKeyword).toBe(newKeyword);
 
-    // Act: 追加ボタンをクリックする
-    act(() => {
-      result.current.addKeywordClick();
+    it("ブックマークを選択してキーワードを解除するとunlinkKeywordが呼び出される", async () => {
+      const { result } = renderMyHook();
+
+      // 1. ブックマークを選択する
+      act(() => {
+        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+      });
+
+      // 2. ブックマーク選択による副作用(useEffect)が完了し、フォームが更新されるのを待つ
+      await waitFor(() => {
+        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+      });
+
+      // 3. キーワード解除をクリックする
+      act(() => {
+        result.current.unlinkKeywordClick(LINKED_KEYWORD);
+      });
+
+      // 4. 結果を検証する
+      await waitFor(() => {
+        // unlinkKeywordの呼び出し
+        expect(unlinkKeyword).toHaveBeenCalledWith(
+          LINKPAGE_BOOKMARK.bookmark_id, // 選択されたブックマークのID
+          LINKED_KEYWORD.keyword_id // 解除されるキーワードのID
+        );
+
+        // エラーメッセージと選択されたブックマーク
+        expect(result.current.textMessage).toBe("");
+        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+      });
     });
 
-    // Assert: addKeywordが呼び出され、フォームがリセットされることを確認する
-    await waitFor(() => {
-      // addKeywordの呼び出し
-      expect(addKeyword).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id, newKeyword);
+    it("ブックマークを選択してキーワードを解除するとlinkKeywordが呼び出される", async () => {
+      const { result } = renderMyHook();
 
-      // エラーメッセージとキーワードのテキストボックス
-      expect(result.current.textMessage).toBe("");
-      expect(result.current.textKeyword).toBe("");
+      // 1. ブックマークを選択する
+      act(() => {
+        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+      });
+
+      // 2. ブックマーク選択による副作用(useEffect)が完了し、フォームが更新されるのを待つ
+      await waitFor(() => {
+        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+      });
+
+      // 3. キーワード解除をクリックする
+      act(() => {
+        result.current.linkKeywordClick(LINKED_KEYWORD);
+      });
+
+      // 4. 結果を検証する
+      await waitFor(() => {
+        // unlinkKeywordの呼び出し
+        expect(addKeyword).toHaveBeenCalledWith(
+          LINKPAGE_BOOKMARK.bookmark_id, // 選択されたブックマークのID
+          LINKED_KEYWORD.keyword_name // 解除されるキーワードの文字列
+        );
+
+        // エラーメッセージと選択されたブックマーク
+        expect(result.current.textMessage).toBe("");
+        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+      });
     });
   });
 
-  it("ブックマークを選択して「削除」ボタンをクリックするとdeleteBookmarkが呼び出される", async () => {
-    const { result } = renderMyHook();
+  describe("エラー系のテスト", () => {
+    it("deleteClick: deleteBookmarkに失敗するとエラーメッセージが表示される", async () => {
+      // Arrange
+      vi.mocked(deleteBookmark).mockRejectedValueOnce(new Error("エラーが発生しました"));
 
-    // 1. ブックマークを選択する
-    act(() => {
-      result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+      const { result } = renderMyHook();
+
+      act(() => {
+        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+      });
+      await waitFor(() => {
+        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+      });
+
+      // Act
+      await act(async () => {
+        await result.current.deleteClick();
+      });
+
+      // Assert
+      await waitFor(() => {
+        // deleteBookmarkの呼び出し
+        expect(deleteBookmark).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id);
+
+        // エラーメッセージと選択されたブックマーク
+        expect(result.current.textMessage).toBe("エラーが発生しました");
+        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+      });
     });
 
-    // 2. ブックマーク選択による副作用(useEffect)が完了し、フォームが更新されるのを待つ
-    await waitFor(() => {
-      expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+    it("updateClick: updateBookmarkに失敗するとエラーメッセージが表示される", async () => {
+      // Arrange
+      vi.mocked(updateBookmark).mockRejectedValueOnce(new Error("エラーが発生しました"));
+
+      const { result } = renderMyHook();
+
+      act(() => {
+        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+      });
+      await waitFor(() => {
+        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+      });
+
+      // Act
+      await act(async () => {
+        await result.current.updateClick();
+      });
+
+      // Assert
+      await waitFor(() => {
+        // deleteBookmarkの呼び出し
+        expect(updateBookmark).toHaveBeenCalledWith(
+          LINKPAGE_BOOKMARK.bookmark_id,
+          LINKPAGE_BOOKMARK.url,
+          LINKPAGE_BOOKMARK.title
+        );
+
+        // エラーメッセージと選択されたブックマーク
+        expect(result.current.textMessage).toBe("エラーが発生しました");
+        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+      });
     });
 
-    // 3. 削除ボタンをクリックする
-    act(() => {
-      result.current.deleteClick();
+    it("addKeywordClick: addKeywordに失敗するとエラーメッセージが表示される", async () => {
+      // Arrange
+      vi.mocked(addKeyword).mockRejectedValueOnce(new Error("エラーが発生しました"));
+
+      const { result } = renderMyHook();
+      const newKeyword = "new keyword";
+
+      act(() => {
+        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+      });
+      await waitFor(() => {
+        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+      });
+
+      act(() => {
+        result.current.setTextKeyword(newKeyword);
+      });
+      await waitFor(() => {
+        expect(result.current.textKeyword).toBe(newKeyword);
+      });
+
+      // Act
+      await act(async () => {
+        await result.current.addKeywordClick();
+      });
+
+      // Assert
+      await waitFor(() => {
+        // addKeywordの呼び出し
+        expect(addKeyword).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id, newKeyword);
+
+        // エラーメッセージと選択されたブックマーク
+        expect(result.current.textMessage).toBe("エラーが発生しました");
+        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+      });
     });
 
-    // 4. 結果を検証する
-    await waitFor(() => {
-      // deleteBookmarkの呼び出し
-      expect(deleteBookmark).toHaveBeenCalledWith(LINKPAGE_BOOKMARK.bookmark_id);
+    it("unlinkKeywordClick: unlinkKeywordに失敗するとエラーメッセージが表示される", async () => {
+      // Arrange
+      vi.mocked(unlinkKeyword).mockRejectedValueOnce(new Error("エラーが発生しました"));
 
-      // エラーメッセージと選択されたブックマーク
-      expect(result.current.textMessage).toBe("");
-      expect(result.current.selectedBookmarkId).toBe(undefined);
-    });
-  });
+      const { result } = renderMyHook();
 
-  it("ブックマークを選択して「更新」ボタンをクリックするとupdateBookmarkが呼び出される", async () => {
-    const { result } = renderMyHook();
+      act(() => {
+        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+      });
+      await waitFor(() => {
+        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+      });
 
-    // 1. ブックマークを選択する
-    act(() => {
-      result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
-    });
+      // Act
+      await act(async () => {
+        await result.current.unlinkKeywordClick(LINKED_KEYWORD);
+      });
 
-    // 2. ブックマーク選択による副作用(useEffect)が完了し、フォームが更新されるのを待つ
-    await waitFor(() => {
-      expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
-    });
+      // Assert
+      await waitFor(() => {
+        // unlinkKeywordの呼び出し
+        expect(unlinkKeyword).toHaveBeenCalledWith(
+          LINKPAGE_BOOKMARK.bookmark_id,
+          LINKED_KEYWORD.keyword_id
+        );
 
-    // 3. 更新ボタンをクリックする
-    act(() => {
-      result.current.updateClick();
-    });
-
-    // 4. 結果を検証する
-    await waitFor(() => {
-      // updateBookmarkの呼び出し
-      expect(updateBookmark).toHaveBeenCalledWith(
-        LINKPAGE_BOOKMARK.bookmark_id,
-        LINKPAGE_BOOKMARK.url,
-        LINKPAGE_BOOKMARK.title
-      );
-
-      // フォームの値が期待通りに設定されていることを確認
-      expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
-      expect(result.current.textTitle).toBe(LINKPAGE_BOOKMARK.title);
-
-      // エラーメッセージとキーワードの選択されたブックマーク
-      expect(result.current.textMessage).toBe("");
-      expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
-    });
-  });
-
-  it("ブックマークを選択しないでキーワードを解除しようとしてもunlinkKeywordは呼び出されない", async () => {
-    const { result } = renderMyHook();
-
-    act(() => {
-      result.current.setSelectedBookmarkId(undefined);
-      result.current.unlinkKeywordClick(LINKED_KEYWORD);
+        // エラーメッセージと選択されたブックマーク
+        expect(result.current.textMessage).toBe("エラーが発生しました");
+        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+      });
     });
 
-    await waitFor(() => {
-      expect(unlinkKeyword).toHaveBeenCalledTimes(0);
-    });
-  });
+    it("linkKeywordClick: addKeywordに失敗するとエラーメッセージが表示される", async () => {
+      // Arrange
+      vi.mocked(addKeyword).mockRejectedValueOnce(new Error("エラーが発生しました"));
 
-  it("ブックマークを選択してキーワードを解除するとunlinkKeywordが呼び出される", async () => {
-    const { result } = renderMyHook();
+      const { result } = renderMyHook();
 
-    // 1. ブックマークを選択する
-    act(() => {
-      result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
-    });
+      act(() => {
+        result.current.setSelectedBookmarkId(LINKPAGE_BOOKMARK.bookmark_id);
+      });
+      await waitFor(() => {
+        expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
+      });
 
-    // 2. ブックマーク選択による副作用(useEffect)が完了し、フォームが更新されるのを待つ
-    await waitFor(() => {
-      expect(result.current.textUrl).toBe(LINKPAGE_BOOKMARK.url);
-    });
+      // Act
+      await act(async () => {
+        await result.current.linkKeywordClick(LINKED_KEYWORD);
+      });
 
-    // 3. キーワード解除をクリックする
-    act(() => {
-      result.current.unlinkKeywordClick(LINKED_KEYWORD);
-    });
+      // Assert
+      await waitFor(() => {
+        // addKeywordの呼び出し
+        expect(addKeyword).toHaveBeenCalledWith(
+          LINKPAGE_BOOKMARK.bookmark_id,
+          LINKED_KEYWORD.keyword_name
+        );
 
-    // 4. 結果を検証する
-    await waitFor(() => {
-      // unlinkKeywordの呼び出し
-      expect(unlinkKeyword).toHaveBeenCalledWith(
-        LINKPAGE_BOOKMARK.bookmark_id, // 選択されたブックマークのID
-        LINKED_KEYWORD.keyword_id // 解除されるキーワードのID
-      );
-
-      // エラーメッセージと選択されたブックマーク
-      expect(result.current.textMessage).toBe("");
-      expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+        // エラーメッセージと選択されたブックマーク
+        expect(result.current.textMessage).toBe("エラーが発生しました");
+        expect(result.current.selectedBookmarkId).toBe(LINKPAGE_BOOKMARK.bookmark_id);
+      });
     });
   });
 });


### PR DESCRIPTION
## 概要

`useBookmarkManager`フックのテストコードの信頼性と保守性を向上させるため、テストの強化と全体的なリファクタリングを実施しました。

## 主な変更点

### 🧪 テストの強化とカバレッジ向上

- **エラーハンドリングの網羅**:
  - `deleteClick`, `updateClick`, `addKeywordClick`, `unlinkKeywordClick`, `linkKeywordClick` の各非同期処理で、APIエラーが発生した場合に正しくエラーメッセージが表示されることを確認するテストケースを追加しました。
- **不正入力パターンの拡充**:
  - ブックマークが選択されていない状態で各操作ボタンをクリックしても、関連する関数が呼び出されないことを確認するテストを統合・明確化しました。
  - 空のキーワードをリンクしようとした場合に、`addKeyword`が呼び出されないことを確認するテストを追加しました。

### ♻️ リファクタリングによる保守性の向上

- **テスト構造の明確化**:
  - テストケースを「初期化時」「不正な入力の場合」「ブックマーク選択後の正常系・エラー系」といった論理的なグループに再構成しました。
- **冗長なコードの削減 (DRY)**:
  - `beforeEach`を活用してブックマーク選択時のセットアップ処理を共通化し、各テストケースの記述を簡潔にしました。
- **可読性の向上**:
  - 各テストの説明文を、UI上の具体的な操作（例: 「〜ボタンをクリックすると」）を反映した表現に修正し、テストの意図をより分かりやすくしました。
  - Arrange-Act-Assert (AAA) パターンを明確に適用し、テストの構造を整理しました。

## 影響範囲

このプルリクエストによる変更はテストコードに限定されており、アプリケーションのランタイム動作への影響はありません。

fixes: #369 