### PR TITLE
feat(bookmark): キーワード選択時に紐付くブックマークを絞り込み表示する

### DIFF
--- a/src/app/components/BookmarkManager.tsx
+++ b/src/app/components/BookmarkManager.tsx
@@ -6,13 +6,14 @@ import {
   DELETE_BUTTON_ROLE_NAME,
   FIELDSET_KEYWORD_LABEL,
   FORM_BOOKMARK_DETAIL,
-  LINK_BUTTON_ROLE_NAME,
   KEYWORD_ROLE_NAME,
+  LINK_BUTTON_ROLE_NAME,
   PARAMETER_BUTTON_ROLE_NAME,
   TABLE_HEADER_ALL_KEYWORD,
   TABLE_HEADER_LINKED_KEYWORD,
-  TABLE_NAME_LINKED_KEYWORD,
+  TABLE_NAME_ALL_BOOKMARK,
   TABLE_NAME_ALL_KEYWORD,
+  TABLE_NAME_LINKED_KEYWORD,
   UNLINK_BUTTON_ROLE_NAME,
   UPDATE_BUTTON_ROLE_NAME,
 } from "../constants/constants";
@@ -85,6 +86,7 @@ export const BookmarkManager = ({ className = "" }: BookmarkManagerProps) => {
       <div className="flex space-x-4">
         <BookmarkTable
           bookmarks={bookmarks}
+          tableName={TABLE_NAME_ALL_BOOKMARK}
           selectedBookmarkId={selectedBookmarkId}
           onSelectBookmarkId={setSelectedBookmarkId}
           selectedKeywordId={selectedKeywordId}

--- a/src/app/components/BookmarkManager.tsx
+++ b/src/app/components/BookmarkManager.tsx
@@ -13,6 +13,7 @@ import {
   TABLE_HEADER_LINKED_KEYWORD,
   TABLE_NAME_ALL_BOOKMARK,
   TABLE_NAME_ALL_KEYWORD,
+  TABLE_NAME_LINKED_BOOKMARKS,
   TABLE_NAME_LINKED_KEYWORD,
   UNLINK_BUTTON_ROLE_NAME,
   UPDATE_BUTTON_ROLE_NAME,
@@ -73,25 +74,43 @@ export const BookmarkManager = ({ className = "" }: BookmarkManagerProps) => {
     unlinkKeyword,
   });
 
-  const { selectedBookmark, selectedKeywords, availableKeywords, isEnableAddKeywordButton } =
-    useBookmarksLogic({
-      bookmarks,
-      keywords,
-      selectedBookmarkId,
-      textKeyword,
-    });
+  const {
+    selectedBookmark,
+    selectedKeywords,
+    availableKeywords,
+    isEnableAddKeywordButton,
+    linkedBookmarkWithSelectedKeywords,
+  } = useBookmarksLogic({
+    bookmarks,
+    keywords,
+    selectedBookmarkId,
+    selectedKeywordId,
+    textKeyword,
+  });
 
   return (
     <div className={`mt-5 mb-5 ${className}`}>
       <div className="flex space-x-4">
-        <BookmarkTable
-          bookmarks={bookmarks}
-          tableName={TABLE_NAME_ALL_BOOKMARK}
-          selectedBookmarkId={selectedBookmarkId}
-          onSelectBookmarkId={setSelectedBookmarkId}
-          selectedKeywordId={selectedKeywordId}
-          className="w-bookmark-list"
-        />
+        <div>
+          {linkedBookmarkWithSelectedKeywords && (
+            <BookmarkTable
+              bookmarks={linkedBookmarkWithSelectedKeywords}
+              tableName={TABLE_NAME_LINKED_BOOKMARKS}
+              selectedBookmarkId={selectedBookmarkId}
+              onSelectBookmarkId={setSelectedBookmarkId}
+              selectedKeywordId={selectedKeywordId}
+              className="w-bookmark-list mb-2"
+            />
+          )}
+          <BookmarkTable
+            bookmarks={bookmarks}
+            tableName={TABLE_NAME_ALL_BOOKMARK}
+            selectedBookmarkId={selectedBookmarkId}
+            onSelectBookmarkId={setSelectedBookmarkId}
+            selectedKeywordId={selectedKeywordId}
+            className="w-bookmark-list"
+          />
+        </div>
         <div className="w-bookmark-details">
           <ErrorMessage
             textMessage={textMessage}

--- a/src/app/components/BookmarkManager.tsx
+++ b/src/app/components/BookmarkManager.tsx
@@ -118,8 +118,9 @@ export const BookmarkManager = ({ className = "" }: BookmarkManagerProps) => {
             handleErrorClose={handleErrorClose}
             className="mb-1 flex justify-center items-center h-8"
           />
-          {selectedBookmark && (
-            <form aria-label={FORM_BOOKMARK_DETAIL} onSubmit={(e) => e.preventDefault()}>
+
+          {selectedBookmark && ( // フォーム内のボタンはtype="button"のため、onSubmitイベントは発生せず、e.preventDefault()は不要
+            <form aria-label={FORM_BOOKMARK_DETAIL}>
               <div className="mb-2 flex justify-between">
                 <ActionButton onClick={updateClick}>{UPDATE_BUTTON_ROLE_NAME}</ActionButton>
                 <ActionButton onClick={deleteClick}>{DELETE_BUTTON_ROLE_NAME}</ActionButton>

--- a/src/app/components/BookmarkManager/linkedBookmark.test.tsx
+++ b/src/app/components/BookmarkManager/linkedBookmark.test.tsx
@@ -1,0 +1,53 @@
+import "@testing-library/jest-dom";
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { screen } from "@testing-library/react";
+import { UserEvent } from "@testing-library/user-event";
+
+import { TABLE_NAME_ALL_BOOKMARK, TABLE_NAME_LINKED_BOOKMARKS } from "../../constants/constants";
+
+import {
+  buildMockBookmarksWithKeywords,
+  mockKeywords,
+  setupBookmarkManagerForTest,
+} from "../../test-utils/bookmarkTestUtils";
+import { Bookmark } from "../../types/Bookmark";
+
+const mockFetch = vi.fn();
+
+describe("選択したキーワードを設定しているブックマークを表示するテーブル", () => {
+  let mockBookmarksWithKeywords: Bookmark[];
+  let user: UserEvent;
+
+  beforeAll(() => {
+    mockBookmarksWithKeywords = buildMockBookmarksWithKeywords();
+  });
+
+  beforeEach(async () => {
+    global.fetch = mockFetch;
+
+    user = await setupBookmarkManagerForTest({
+      fetchForSetup: mockFetch,
+      bookmarksForSetup: mockBookmarksWithKeywords,
+    });
+  });
+
+  it("キーワードを選択していない場合、すべてのブックマークテーブルは表示されるが、関連ブックマークテーブルは表示されない", async () => {
+    // すべてのブックマークテーブルは常に表示されている
+    expect(screen.getByRole("table", { name: TABLE_NAME_ALL_BOOKMARK })).toBeInTheDocument();
+    // 関連ブックマークテーブルは表示されていない
+    expect(
+      screen.queryByRole("table", { name: TABLE_NAME_LINKED_BOOKMARKS })
+    ).not.toBeInTheDocument();
+  });
+
+  describe("キーワードを選択した場合", () => {
+    it("キーワードを選択すると、関連ブックマークテーブルが表示される", async () => {
+      const keywordCell = screen.getByText(mockKeywords[0].keyword_name);
+      await user.click(keywordCell);
+
+      expect(screen.getByRole("table", { name: TABLE_NAME_LINKED_BOOKMARKS })).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/components/BookmarkManager/update.test.tsx
+++ b/src/app/components/BookmarkManager/update.test.tsx
@@ -6,7 +6,7 @@ import { screen, waitFor, within } from "@testing-library/react";
 import { UserEvent } from "@testing-library/user-event";
 
 import { BOOKMARKS_ENDPOINT } from "../../constants/apiEndpoints";
-import { TABLE_NAME_BOOKMARKS, UPDATE_BUTTON_ROLE_NAME } from "../../constants/constants";
+import { TABLE_NAME_ALL_BOOKMARK, UPDATE_BUTTON_ROLE_NAME } from "../../constants/constants";
 import {
   HTTP_STATUS_BAD_REQUEST,
   HTTP_STATUS_CONFLICT,
@@ -146,7 +146,7 @@ describe("タイトルの更新ボタン", () => {
           buttonName: UPDATE_BUTTON_ROLE_NAME,
         });
 
-        const table = await screen.findByRole("table", { name: TABLE_NAME_BOOKMARKS });
+        const table = await screen.findByRole("table", { name: TABLE_NAME_ALL_BOOKMARK });
         await within(table).findByText(bookmarkToSelect.title);
       });
 

--- a/src/app/components/BookmarkTable.test.tsx
+++ b/src/app/components/BookmarkTable.test.tsx
@@ -9,7 +9,6 @@ import {
   ROW_STYLE_BOOKMARK_SELECTED,
   ROW_STYLE_KEYWORD_SELECTED,
   TABLE_NAME_ALL_BOOKMARK,
-  TABLE_NAME_BOOKMARKS,
 } from "../constants/constants";
 import {
   buildMockBookmarksWithKeywords,
@@ -42,7 +41,7 @@ describe("BookmarkTableのテスト", () => {
   it("テーブルとヘッダーが正しく表示される", () => {
     renderComponent();
 
-    const table = screen.getByRole("table", { name: TABLE_NAME_BOOKMARKS });
+    const table = screen.getByRole("table", { name: TABLE_NAME_ALL_BOOKMARK });
     expect(table).toBeVisible();
 
     const headers = within(table).getAllByRole("columnheader");

--- a/src/app/components/BookmarkTable.test.tsx
+++ b/src/app/components/BookmarkTable.test.tsx
@@ -8,6 +8,7 @@ import {
   BASE_CELL_STYLE,
   ROW_STYLE_BOOKMARK_SELECTED,
   ROW_STYLE_KEYWORD_SELECTED,
+  TABLE_NAME_ALL_BOOKMARK,
   TABLE_NAME_BOOKMARKS,
 } from "../constants/constants";
 import {
@@ -29,6 +30,7 @@ describe("BookmarkTableのテスト", () => {
     render(
       <BookmarkTable
         bookmarks={customBookmarks}
+        tableName={TABLE_NAME_ALL_BOOKMARK}
         selectedBookmarkId={undefined}
         onSelectBookmarkId={mockOnSelectBookmark}
         selectedKeywordId={undefined}
@@ -45,7 +47,7 @@ describe("BookmarkTableのテスト", () => {
 
     const headers = within(table).getAllByRole("columnheader");
     expect(headers).toHaveLength(1);
-    expect(headers[0]).toHaveTextContent("タイトル");
+    expect(headers[0]).toHaveTextContent(TABLE_NAME_ALL_BOOKMARK);
 
     expect(mockOnSelectBookmark).not.toHaveBeenCalled();
   });
@@ -60,7 +62,7 @@ describe("BookmarkTableのテスト", () => {
     expect(headerRows).toHaveLength(1);
     const headerCells = within(headerRows[0]).getAllByRole("columnheader");
     expect(headerCells).toHaveLength(1);
-    expect(headerCells[0]).toHaveTextContent("タイトル");
+    expect(headerCells[0]).toHaveTextContent(TABLE_NAME_ALL_BOOKMARK);
 
     const bodyRows = within(tbody).getAllByRole("row");
     expect(bodyRows).toHaveLength(mockBookmarks.length);

--- a/src/app/components/BookmarkTable.tsx
+++ b/src/app/components/BookmarkTable.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { BASE_CELL_STYLE, TABLE_NAME_BOOKMARKS, TITLE_CELL_STYLE } from "../constants/constants";
+import { BASE_CELL_STYLE, TITLE_CELL_STYLE } from "../constants/constants";
 import { useBookmarkTable } from "../hooks/useBookmarkTable";
 import { Bookmark } from "../types/Bookmark";
 
@@ -29,7 +29,7 @@ export const BookmarkTable = ({
   });
 
   return (
-    <table aria-label={TABLE_NAME_BOOKMARKS} className={className}>
+    <table aria-label={tableName} className={className}>
       <thead>
         <tr>
           <th className={`${TITLE_CELL_STYLE} ${BASE_CELL_STYLE}`} scope="col">

--- a/src/app/components/BookmarkTable.tsx
+++ b/src/app/components/BookmarkTable.tsx
@@ -6,6 +6,7 @@ import { Bookmark } from "../types/Bookmark";
 
 type BookmarkTableProps = {
   bookmarks: Bookmark[];
+  tableName: string;
   selectedBookmarkId: number | undefined;
   onSelectBookmarkId: (bookmarkId: number) => void;
   selectedKeywordId: number | undefined;
@@ -14,6 +15,7 @@ type BookmarkTableProps = {
 
 export const BookmarkTable = ({
   bookmarks,
+  tableName,
   selectedBookmarkId,
   onSelectBookmarkId,
   selectedKeywordId,
@@ -31,7 +33,7 @@ export const BookmarkTable = ({
       <thead>
         <tr>
           <th className={`${TITLE_CELL_STYLE} ${BASE_CELL_STYLE}`} scope="col">
-            タイトル
+            {tableName}
           </th>
         </tr>
       </thead>

--- a/src/app/constants/constants.ts
+++ b/src/app/constants/constants.ts
@@ -13,12 +13,12 @@ export const FIELDSET_KEYWORD_LABEL = "キーワード入力";
 export const KEYWORD_ROLE_NAME = "キーワード";
 export const ADD_BUTTON_ROLE_NAME = "追加";
 export const TABLE_NAME_ALL_BOOKMARK = "すべてのブックマークのテーブル";
-export const TABLE_NAME_LINKED_KEYWORD = "設定されたキーワードのテーブル";
+export const TABLE_NAME_LINKED_BOOKMARKS =
+  "選択されたキーワードが設定されているブックマークのテーブル";
 export const TABLE_NAME_ALL_KEYWORD = "すべてのキーワードのテーブル";
+export const TABLE_NAME_LINKED_KEYWORD = "設定されているキーワードのテーブル";
 export const TABLE_HEADER_LINKED_KEYWORD = "設定されているキーワード";
 export const TABLE_HEADER_ALL_KEYWORD = "設定されていないキーワード";
-
-export const TABLE_NAME_BOOKMARKS = "ブックマークのテーブル";
 
 export const ROW_STYLE_BOOKMARK_SELECTED = "border-4 font-bold";
 export const ROW_STYLE_BOOKMARK_UNSELECTED = "";

--- a/src/app/constants/constants.ts
+++ b/src/app/constants/constants.ts
@@ -12,6 +12,7 @@ export const FORM_BOOKMARK_DETAIL = "ブックマーク詳細フォーム";
 export const FIELDSET_KEYWORD_LABEL = "キーワード入力";
 export const KEYWORD_ROLE_NAME = "キーワード";
 export const ADD_BUTTON_ROLE_NAME = "追加";
+export const TABLE_NAME_ALL_BOOKMARK = "すべてのブックマークのテーブル";
 export const TABLE_NAME_LINKED_KEYWORD = "設定されたキーワードのテーブル";
 export const TABLE_NAME_ALL_KEYWORD = "すべてのキーワードのテーブル";
 export const TABLE_HEADER_LINKED_KEYWORD = "設定されているキーワード";

--- a/src/app/hooks/useBookmarkLogic.test.ts
+++ b/src/app/hooks/useBookmarkLogic.test.ts
@@ -2,17 +2,33 @@ import { describe, expect, it } from "vitest";
 
 import { renderHook } from "@testing-library/react";
 
-import { buildMockBookmarksWithKeywords, mockKeywords } from "../test-utils/bookmarkTestUtils";
+import {
+  buildMockBookmarksWithKeywords,
+  LINKED_KEYWORD,
+  mockKeywords,
+  NOLINKED_KEYWORD,
+} from "../test-utils/bookmarkTestUtils";
 import { useBookmarksLogic } from "./useBookmarkLogic";
 import { Bookmark } from "../types/Bookmark";
 
 const mockBookmarksWithKeywords = buildMockBookmarksWithKeywords();
 
-const renderMyHook = (selectedBookmarkId?: number, textKeyword: string = "") => {
+type RenderMyHookProps = {
+  selectedBookmarkId?: number;
+  selectedKeywordId?: number;
+  textKeyword?: string;
+};
+
+const renderMyHook = ({
+  selectedBookmarkId,
+  selectedKeywordId,
+  textKeyword = "",
+}: RenderMyHookProps = {}) => {
   return renderHook(() =>
     useBookmarksLogic({
       bookmarks: mockBookmarksWithKeywords,
       selectedBookmarkId,
+      selectedKeywordId,
       keywords: mockKeywords,
       textKeyword,
     })
@@ -47,7 +63,7 @@ describe("useBookmarkLogic", () => {
       "$title: 対応するブックマークとキーワードが選択されること、設定可能なキーワードが表示される",
       (bookmark: Bookmark) => {
         // Arrange & Act
-        const { result } = renderMyHook(bookmark.bookmark_id);
+        const { result } = renderMyHook({ selectedBookmarkId: bookmark.bookmark_id });
 
         // Assert
         expect(result.current.selectedBookmark).toEqual(bookmark);
@@ -91,10 +107,40 @@ describe("useBookmarkLogic", () => {
     ];
     it.each(testKeywordCases)("$description: 入力されたキーワード", ({ textKeyword, expected }) => {
       // Arrange & Act
-      const { result } = renderMyHook(undefined, textKeyword);
+      const { result } = renderMyHook({ textKeyword });
 
       // Assert
       expect(result.current.isEnableAddKeywordButton).toBe(expected);
+    });
+  });
+
+  describe("選択されたキーワードが設定されているブックマーク(linkedBookmarkWithSelectedKeywords)のテスト", () => {
+    it("キーワードが選択されていない場合にはundefinedを返すこと", () => {
+      // Arrange & Act
+      const { result } = renderMyHook();
+
+      // Assert
+      expect(result.current.linkedBookmarkWithSelectedKeywords).toBeUndefined();
+    });
+
+    describe("キーワードが選択されている場合", () => {
+      it("ブックマークに設定されていないキーワード", () => {
+        // Arrange & Act
+        const { result } = renderMyHook({ selectedKeywordId: NOLINKED_KEYWORD.keyword_id });
+
+        // Assert
+        expect(result.current.linkedBookmarkWithSelectedKeywords).toEqual([]);
+      });
+
+      it("ブックマークに設定されているキーワード", () => {
+        // Arrange & Act
+        const { result } = renderMyHook({ selectedKeywordId: LINKED_KEYWORD.keyword_id });
+
+        // Assert
+        expect(result.current.linkedBookmarkWithSelectedKeywords).toEqual([
+          mockBookmarksWithKeywords[1],
+        ]);
+      });
     });
   });
 });

--- a/src/app/hooks/useBookmarkLogic.ts
+++ b/src/app/hooks/useBookmarkLogic.ts
@@ -6,6 +6,7 @@ import { Keyword } from "../types/Keyword";
 type UseBookmarksLogicProps = {
   bookmarks: Bookmark[];
   selectedBookmarkId: number | undefined;
+  selectedKeywordId?: number | undefined;
   keywords: Keyword[];
   textKeyword: string;
 };
@@ -13,6 +14,7 @@ type UseBookmarksLogicProps = {
 export const useBookmarksLogic = ({
   bookmarks,
   selectedBookmarkId,
+  selectedKeywordId = undefined,
   keywords,
   textKeyword,
 }: UseBookmarksLogicProps) => {
@@ -44,10 +46,18 @@ export const useBookmarksLogic = ({
     return !existingKeywordNames.has(normalizedKeyword);
   }, [textKeyword, existingKeywordNames]);
 
+  const linkedBookmarkWithSelectedKeywords = useMemo(() => {
+    if (selectedKeywordId === undefined) {
+      return undefined;
+    }
+    return bookmarks.filter((b) => b.keywords.some((k) => k.keyword_id === selectedKeywordId));
+  }, [bookmarks, selectedKeywordId]);
+
   return {
     selectedBookmark,
     selectedKeywords,
     availableKeywords,
     isEnableAddKeywordButton,
+    linkedBookmarkWithSelectedKeywords,
   };
 };

--- a/src/app/test-utils/bookmarkTestUtils.tsx
+++ b/src/app/test-utils/bookmarkTestUtils.tsx
@@ -6,7 +6,7 @@ import userEvent, { UserEvent } from "@testing-library/user-event";
 import { BookmarkManager } from "../components/BookmarkManager";
 import {
   FORM_BOOKMARK_DETAIL,
-  TABLE_NAME_BOOKMARKS,
+  TABLE_NAME_ALL_BOOKMARK,
   TITLE_ROLE_NAME,
   URL_ROLE_NAME,
 } from "../constants/constants";
@@ -79,7 +79,7 @@ export const assertNoBookmarkIsSelected = async () => {
 };
 
 export const getCellWithTitle = (title: string) => {
-  const table = screen.getByRole("table", { name: TABLE_NAME_BOOKMARKS });
+  const table = screen.getByRole("table", { name: TABLE_NAME_ALL_BOOKMARK });
 
   const cellWithTitle = within(table).getByRole("cell", { name: title });
   return cellWithTitle;
@@ -330,7 +330,7 @@ export const setupBookmarkManagerForTest = async ({
     json: async () => keywordsForSetup,
   });
   render(<BookmarkManager />);
-  await screen.findByRole("table", { name: TABLE_NAME_BOOKMARKS });
+  await screen.findByRole("table", { name: TABLE_NAME_ALL_BOOKMARK });
   return userEvent.setup();
 };
 


### PR DESCRIPTION
## 概要

キーワードが選択された際に、そのキーワードが設定されているブックマークのみを絞り込んで一覧表示する機能を追加しました。これにより、ユーザーは特定のキーワードに関連するブックマークを素早く見つけることができるようになります。

## 変更内容

-   **キーワードによるブックマーク絞り込み表示**:
    -   キーワードテーブルのキーワードをクリックすると、そのキーワードが設定されているブックマークのリストが「すべてのブックマーク」テーブルの上に表示されます。
-   **ロジックの追加**:
    -   `useBookmarksLogic`フックに、選択されたキーワードIDに基づいてブックマークをフィルタリングするロジック (`linkedBookmarkWithSelectedKeywords`) を追加しました。
-   **コンポーネントの汎用化**:
    -   新機能の実装に伴い、`BookmarkTable`コンポーネントをリファクタリングし、テーブルのヘッダーテキスト(`tableName`)と`aria-label`をprops経由で設定できるように変更しました。これにより、コンポーネントの再利用性が向上しました。
-   **定数の見直し**:
    -   `TABLE_NAME_BOOKMARKS`をより具体的な`TABLE_NAME_ALL_BOOKMARK`に置き換え、新しく`TABLE_NAME_LINKED_BOOKMARKS`を追加するなど、定数名をより明確にしました。
-   **テストの追加**:
    -   TDD（テスト駆動開発）のアプローチに基づき、本機能に関するテストケースを追加しました。

## 動作確認

1.  アプリケーションを起動します。
2.  右側の「設定されていないキーワード」テーブルから、いずれかのキーワードをクリックします。
3.  左側のブックマークリストの上に、選択したキーワードが設定されているブックマークのみを含む「選択されたキーワードが設定されているブックマークのテーブル」が新しく表示されることを確認します。
4.  再度同じキーワードをクリックして選択を解除すると、そのテーブルが非表示になることを確認します。

fixes: #372 