### PR TITLE
feat(hooks): 独自キーハンドラフックを導入し `react-hotkeys-hook` を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,15 @@ linkpage はリンクデータを SQLite のデータベースで管理します
 
 ## 変更履歴
 
+### ✨ feat: 2025/10/03 独自キーハンドラフックを導入し `react-hotkeys-hook` を削除
+
+#### 変更内容
+
+- `useKeyHandler` カスタムフックを新規作成
+- `useKeyHandler` のための単体テストを追加
+- `useBookmarkManager` で `useHotkeys` の代わりに `useKeyHandler` を使用するようにリファクタリング
+- `package.json` と `package-lock.json` から `react-hotkeys-hook` を削除
+
 ### ✨ feat: 2025/09/30 キーワード選択時に紐付くブックマークを絞り込み表示
 
 #### 変更内容

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
         "better-sqlite3": "^12.2.0",
         "next": "15.5.3",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1",
-        "react-hotkeys-hook": "^5.1.0"
+        "react-dom": "^19.1.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -6848,19 +6847,6 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
-      }
-    },
-    "node_modules/react-hotkeys-hook": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-5.1.0.tgz",
-      "integrity": "sha512-GCNGXjBzV9buOS3REoQFmSmE4WTvBhYQ0YrAeeMZI83bhXg3dRWsLHXDutcVDdEjwJqJCxk5iewWYX5LtFUd7g==",
-      "license": "MIT",
-      "workspaces": [
-        "packages/*"
-      ],
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkpage",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkpage",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "dependencies": {
         "better-sqlite3": "^12.2.0",
         "next": "15.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkpage",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "better-sqlite3": "^12.2.0",
     "next": "15.5.3",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1",
-    "react-hotkeys-hook": "^5.1.0"
+    "react-dom": "^19.1.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/src/app/hooks/useBookmarkManager.ts
+++ b/src/app/hooks/useBookmarkManager.ts
@@ -1,12 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useHotkeys } from "react-hotkeys-hook";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { getErrorMessage } from "../api/utils/ApiUtils";
 import { Bookmark } from "../types/Bookmark";
-import { useErrorMessage } from "./useErrorMessage";
 import { Keyword } from "../types/Keyword";
+import { useErrorMessage } from "./useErrorMessage";
+import { useKeyHandler } from "./useKeyHandler";
 
 type UseBookmarkManagerProps = {
   bookmarks: Bookmark[];
@@ -186,71 +186,63 @@ export const useBookmarkManager = ({
     selectedBookmarkIdRef.current = selectedBookmarkId;
   }, [selectedBookmarkId]);
 
-  // getSelectedBookmarkIndex は useHotkeys の内部で定義し、ref を使用する
-  useHotkeys(
-    "enter, escape, arrowup, arrowdown",
-    (_, handler) => {
-      const key = handler.keys?.[0];
-      if (!key) {
+  const keyHandlerMap = useMemo(() => {
+    const getSelectedBookmarkIndexInternal = () => {
+      const currentSelectedBookmarkId = selectedBookmarkIdRef.current;
+      const currentBookmarks = bookmarksRef.current;
+      if (currentSelectedBookmarkId === undefined) {
+        return undefined;
+      }
+      const currentIndex = currentBookmarks.findIndex(
+        (bookmark) => bookmark.bookmark_id === currentSelectedBookmarkId
+      );
+      if (currentIndex === -1) {
+        return undefined;
+      }
+      return currentIndex;
+    };
+
+    const handleArrowKey = (key: "ArrowUp" | "ArrowDown") => {
+      const currentBookmarks = bookmarksRef.current;
+      if (currentBookmarks.length === 0) {
         return true;
       }
-      // ホットキーハンドラ内で最新のブックマークと選択状態を参照するためのヘルパー関数
-      const getSelectedBookmarkIndexInternal = () => {
-        const currentSelectedBookmarkId = selectedBookmarkIdRef.current;
-        const currentBookmarks = bookmarksRef.current;
-        if (currentSelectedBookmarkId === undefined) {
-          return undefined;
-        }
-        const currentIndex = currentBookmarks.findIndex(
-          (bookmark) => bookmark.bookmark_id === currentSelectedBookmarkId
-        );
-        if (currentIndex === -1) {
-          return undefined;
-        }
-        return currentIndex;
-      };
-      if (key === "arrowup" || key === "arrowdown") {
-        const currentBookmarks = bookmarksRef.current;
-        if (currentBookmarks.length === 0) {
-          return true;
-        }
-        const currentIndex = getSelectedBookmarkIndexInternal();
-        const increment = key === "arrowdown" ? 1 : -1;
-        let newIndex;
-        if (currentIndex === undefined) {
-          // ブックマークが選択されていない場合、最初または最後に移動
-          newIndex = increment === 1 ? 0 : currentBookmarks.length - 1;
-        } else {
-          // ブックマークを循環
-          newIndex = (currentIndex + increment + currentBookmarks.length) % currentBookmarks.length;
-        }
-        setSelectedBookmarkId(currentBookmarks[newIndex].bookmark_id);
-        return false; // Prevent default scroll
+      const currentIndex = getSelectedBookmarkIndexInternal();
+      const increment = key === "ArrowDown" ? 1 : -1;
+      let newIndex;
+      if (currentIndex === undefined) {
+        // ブックマークが選択されていない場合、最初または最後に移動
+        newIndex = increment === 1 ? 0 : currentBookmarks.length - 1;
+      } else {
+        // ブックマークを循環
+        newIndex = (currentIndex + increment + currentBookmarks.length) % currentBookmarks.length;
       }
-      // 以降のキー操作はブックマーク選択中のみ有効
-      if (selectedBookmarkIdRef.current === undefined) {
-        return true;
-      }
-      switch (key) {
-        case "enter":
+      setSelectedBookmarkId(currentBookmarks[newIndex].bookmark_id);
+      return false; // Prevent default scroll
+    };
+
+    return {
+      ArrowUp: () => handleArrowKey("ArrowUp"),
+      ArrowDown: () => handleArrowKey("ArrowDown"),
+      Enter: () => {
+        if (selectedBookmarkIdRef.current !== undefined) {
           openBookmark();
           return false; // Prevent default
-        case "escape":
+        }
+        return true;
+      },
+      Escape: () => {
+        if (selectedBookmarkIdRef.current !== undefined) {
           setSelectedBookmarkId(undefined);
           setSelectedKeywordId(undefined);
           return false; // Prevent default
-        default:
-          return true;
-      }
-    },
-    [
-      openBookmark,
-      setSelectedBookmarkId,
-      // bookmarks, selectedBookmark, textUrl は ref を介してアクセスされるため、
-      // 依存配列から除外しています。
-      // isBookmarkSelected もインライン化されたため、依存配列から削除されます。
-    ]
-  );
+        }
+        return true;
+      },
+    };
+  }, [openBookmark, setSelectedBookmarkId, setSelectedKeywordId]);
+
+  useKeyHandler(keyHandlerMap);
 
   const addKeywordClick = useCallback(async () => {
     const normalizedTextKeyword = textKeyword.trim();

--- a/src/app/hooks/useKeyHandler.test.ts
+++ b/src/app/hooks/useKeyHandler.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { fireEvent } from "@testing-library/dom";
+import { renderHook } from "@testing-library/react";
+
+import { useKeyHandler } from "./useKeyHandler";
+
+describe("useKeyHandler", () => {
+  it("should call the correct handler when a key is pressed", () => {
+    const enterHandler = vi.fn();
+    const escapeHandler = vi.fn();
+    const keyHandlerMap = {
+      Enter: enterHandler,
+      Escape: escapeHandler,
+    };
+
+    renderHook(() => useKeyHandler(keyHandlerMap));
+
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(enterHandler).toHaveBeenCalledTimes(1);
+    expect(escapeHandler).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(escapeHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not call any handler for an unmapped key", () => {
+    const enterHandler = vi.fn();
+    const keyHandlerMap = {
+      Enter: enterHandler,
+    };
+
+    renderHook(() => useKeyHandler(keyHandlerMap));
+
+    fireEvent.keyDown(window, { key: "a" });
+    expect(enterHandler).not.toHaveBeenCalled();
+  });
+
+  it("should prevent default and stop propagation if handler returns false", () => {
+    const handler = vi.fn(() => false);
+    const keyHandlerMap = {
+      " ": handler,
+    };
+    renderHook(() => useKeyHandler(keyHandlerMap));
+
+    const event = new KeyboardEvent("keydown", { key: " " });
+    const preventDefaultSpy = vi.spyOn(event, "preventDefault");
+    const stopPropagationSpy = vi.spyOn(event, "stopPropagation");
+
+    window.dispatchEvent(event);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+    expect(stopPropagationSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not prevent default or stop propagation if handler does not return false", () => {
+    const handler = vi.fn(() => undefined); // or returns true or void
+    const keyHandlerMap = {
+      Tab: handler,
+    };
+    renderHook(() => useKeyHandler(keyHandlerMap));
+
+    const event = new KeyboardEvent("keydown", { key: "Tab" });
+    const preventDefaultSpy = vi.spyOn(event, "preventDefault");
+    const stopPropagationSpy = vi.spyOn(event, "stopPropagation");
+
+    window.dispatchEvent(event);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+    expect(stopPropagationSpy).not.toHaveBeenCalled();
+  });
+
+  it("should add and remove event listener on mount and unmount", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const { unmount } = renderHook(() => useKeyHandler({}));
+
+    expect(addSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
+  });
+});

--- a/src/app/hooks/useKeyHandler.ts
+++ b/src/app/hooks/useKeyHandler.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect } from "react";
+
+type KeyHandlerMap = {
+  [key: string]: (event: KeyboardEvent) => void | boolean;
+};
+
+export const useKeyHandler = (keyHandlerMap: KeyHandlerMap) => {
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      const handler = keyHandlerMap[event.key];
+      if (handler) {
+        const result = handler(event);
+        if (result === false) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+      }
+    },
+    [keyHandlerMap]
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleKeyDown]);
+};


### PR DESCRIPTION
## 概要

`react-hotkeys-hook` への依存を解消し、よりシンプルで軽量な独自のカスタムフック `useKeyHandler` に置き換えます。

この変更により、外部ライブラリへの依存が一つ削減され、バンドルサイズの軽量化と、アプリケーション固有の要件に合わせたキーボードイベント処理の簡素化が実現されます。

## 主な変更点

- `useKeyHandler` カスタムフックを新規作成
- `useKeyHandler` のための単体テストを追加
- `useBookmarkManager` で `useHotkeys` の代わりに `useKeyHandler` を使用するようにリファクタリング
- `package.json` と `package-lock.json` から `react-hotkeys-hook` を削除

## 影響

- 外部依存関係が削減され、アプリケーションのメンテナンス性が向上します。
- バンドルサイズが軽量化されます。

fixes: #374 